### PR TITLE
Implement simple MongoDB login with mobile layout

### DIFF
--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getClient } from '../../../utils/db';
+
+export async function POST(request: Request) {
+  const { username, password } = await request.json();
+  const client = await getClient();
+  const user = await client.db('gameplaner').collection('users').findOne({ username, password });
+  if (user) {
+    return NextResponse.json({ success: true });
+  }
+  return NextResponse.json({ success: false, error: 'Invalid credentials' }, { status: 401 });
+}

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  return NextResponse.json({ success: true });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
       <body className={inter.className}>{children}</body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
+import { Container, TextField, Button, Typography, Box } from '@mui/material';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async () => {
+    try {
+      const res = await axios.post('/api/login', { username, password });
+      if (res.data.success) {
+        localStorage.setItem('loggedIn', 'true');
+        router.push('/');
+      }
+    } catch (e: any) {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <Container maxWidth="xs">
+      <Typography variant="h5" mt={4}>Login</Typography>
+      <Box mt={2}>
+        <TextField label="Username" fullWidth margin="normal" value={username} onChange={e => setUsername(e.target.value)} />
+        <TextField label="Password" type="password" fullWidth margin="normal" value={password} onChange={e => setPassword(e.target.value)} />
+        {error && <Typography color="error">{error}</Typography>}
+        <Button variant="contained" fullWidth sx={{ mt: 2 }} onClick={handleSubmit}>Login</Button>
+      </Box>
+    </Container>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,9 @@ const Home: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // Load data from local storage
+    if (typeof window !== 'undefined' && !localStorage.getItem('loggedIn')) {
+      window.location.href = '/login';
+    }
     const savedSchedule = localStorage.getItem('schedule');
     const savedScores = localStorage.getItem('scores');
     if (savedSchedule) {
@@ -32,6 +34,12 @@ const Home: React.FC = () => {
       setScores(JSON.parse(savedScores));
     }
   }, []);
+
+  const handleLogout = async () => {
+    await axios.post('/api/logout');
+    localStorage.removeItem('loggedIn');
+    window.location.href = '/login';
+  };
 
   const handlePlayerListChange = (team: 'A' | 'B', value: string) => {
     if (team === 'A') {
@@ -165,12 +173,15 @@ const Home: React.FC = () => {
   const teamBscoreDifference = totalTeamBScore - totalTeamAScore;
 
   return (
-    <Container>
-      <Typography variant="h4" gutterBottom>
-        Badminton Match Scheduler
-      </Typography>
+    <Container maxWidth="sm">
+      <Box display="flex" justifyContent="space-between" alignItems="center">
+        <Typography variant="h4" gutterBottom>
+          Badminton Match Scheduler
+        </Typography>
+        <Button variant="outlined" onClick={handleLogout}>Logout</Button>
+      </Box>
       <Grid container spacing={2}>
-        <Grid item xs={9}>
+        <Grid item xs={12} md={9}>
           <TextField
             label="Team A Member List"
             type='text'
@@ -196,7 +207,7 @@ const Home: React.FC = () => {
             Number of players in Team B: {teamBPlayerCount}
           </Typography>
         </Grid>
-        <Grid item xs={3}>
+        <Grid item xs={12} md={3}>
           <TextField
             label="Number of Courts"
             type="number"

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1,0 +1,21 @@
+import { MongoClient, ServerApiVersion } from 'mongodb';
+
+const uri = "mongodb+srv://yinchuan:HYChyc86128958!!@cluster0.kb5m8qt.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0";
+
+let client: MongoClient | null = null;
+
+export async function getClient() {
+  if (!client) {
+    client = new MongoClient(uri, {
+      serverApi: {
+        version: ServerApiVersion.v1,
+        strict: true,
+        deprecationErrors: true,
+      },
+    });
+    await client.connect();
+    await client.db('admin').command({ ping: 1 });
+    console.log('Pinged your deployment. You successfully connected to MongoDB!');
+  }
+  return client;
+}


### PR DESCRIPTION
## Summary
- add viewport meta for mobile support
- create MongoDB helper and login/logout API routes
- add login page and logout button
- make scheduler page responsive for mobile

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d0815e4508322b55750cb3bd42022