### PR TITLE
Add sign up page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+Before accessing the main scheduler you need an account. Visit `/signup` to create one and then log in at `/login`.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { getClient } from '../../../utils/db';
+
+export async function POST(request: Request) {
+  const { username, password } = await request.json();
+  const client = await getClient();
+  const db = client.db('gameplaner');
+  const existing = await db.collection('users').findOne({ username });
+  if (existing) {
+    return NextResponse.json({ success: false, error: 'User exists' }, { status: 400 });
+  }
+  await db.collection('users').insertOne({ username, password });
+  return NextResponse.json({ success: true });
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -5,33 +5,38 @@ import axios from 'axios';
 import { Container, TextField, Button, Typography, Box } from '@mui/material';
 import Link from 'next/link';
 
-export default function LoginPage() {
+export default function SignupPage() {
   const router = useRouter();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
 
   const handleSubmit = async () => {
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
     try {
-      const res = await axios.post('/api/login', { username, password });
+      const res = await axios.post('/api/signup', { username, password });
       if (res.data.success) {
-        localStorage.setItem('loggedIn', 'true');
-        router.push('/');
+        router.push('/login');
       }
     } catch (e: any) {
-      setError('Login failed');
+      setError('Signup failed');
     }
   };
 
   return (
     <Container maxWidth="xs">
-      <Typography variant="h5" mt={4}>Login</Typography>
+      <Typography variant="h5" mt={4}>Sign Up</Typography>
       <Box mt={2}>
         <TextField label="Username" fullWidth margin="normal" value={username} onChange={e => setUsername(e.target.value)} />
         <TextField label="Password" type="password" fullWidth margin="normal" value={password} onChange={e => setPassword(e.target.value)} />
+        <TextField label="Confirm Password" type="password" fullWidth margin="normal" value={confirmPassword} onChange={e => setConfirmPassword(e.target.value)} />
         {error && <Typography color="error">{error}</Typography>}
-        <Button variant="contained" fullWidth sx={{ mt: 2 }} onClick={handleSubmit}>Login</Button>
-        <Button component={Link} href="/signup" fullWidth sx={{ mt: 1 }}>Sign Up</Button>
+        <Button variant="contained" fullWidth sx={{ mt: 2 }} onClick={handleSubmit}>Sign Up</Button>
+        <Button component={Link} href="/login" fullWidth sx={{ mt: 1 }}>Back to Login</Button>
       </Box>
     </Container>
   );


### PR DESCRIPTION
## Summary
- add instructions in README on signing up
- add API route for sign up
- link login page to sign up page
- implement signup page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d0a3e8528832297ada5fc2376d025