### PR TITLE
Use env var for database URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Local Environment Setup
+
+1. Create a `.env.local` file in the root of the project.
+2. Inside that file, define the `DB_URL` variable with your MongoDB connection string:
+
+   ```env
+   DB_URL=your_mongodb_connection_string
+   ```
+
+3. Run the development server with `npm run dev`.
+
+This `.env.local` file is ignored by git and should not be committed.

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1,6 +1,9 @@
 import { MongoClient, ServerApiVersion } from 'mongodb';
 
-const uri = "mongodb+srv://yinchuan:HYChyc86128958!!@cluster0.kb5m8qt.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0";
+const uri = process.env.DB_URL;
+if (!uri) {
+  throw new Error('DB_URL environment variable is not set');
+}
 
 let client: MongoClient | null = null;
 


### PR DESCRIPTION
## Summary
- read DB URL from the `DB_URL` environment variable
- document local setup for the database connection

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_684d0da5230c8322837cc2d2a7e6dd17