### PR TITLE
Add mongoose models and super-admin role management

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ bun dev
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 Before accessing the main scheduler you need an account. Visit `/signup` to create one and then log in at `/login`.
+Super admins can manage user roles at `/manage`.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
@@ -40,7 +41,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 ## Local Environment Setup
 
 1. Create a `.env.local` file in the root of the project.
-2. Inside that file, define the `DB_URL` variable with your MongoDB connection string:
+2. Inside that file, define the `DB_URL` variable with your MongoDB connection string used by Mongoose:
 
    ```env
    DB_URL=your_mongodb_connection_string

--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server';
-import { getClient } from '../../../utils/db';
+import connect from '../../../utils/mongoose';
+import User from '../../../models/User';
 
 export async function POST(request: Request) {
   const { username, password } = await request.json();
-  const client = await getClient();
-  const user = await client.db('gameplaner').collection('users').findOne({ username, password });
+  await connect();
+  const user = await User.findOne({ username, password });
   if (user) {
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, role: user.role });
   }
   return NextResponse.json({ success: false, error: 'Invalid credentials' }, { status: 401 });
 }

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,14 +1,14 @@
 import { NextResponse } from 'next/server';
-import { getClient } from '../../../utils/db';
+import connect from '../../../utils/mongoose';
+import User from '../../../models/User';
 
 export async function POST(request: Request) {
   const { username, password } = await request.json();
-  const client = await getClient();
-  const db = client.db('gameplaner');
-  const existing = await db.collection('users').findOne({ username });
+  await connect();
+  const existing = await User.findOne({ username });
   if (existing) {
     return NextResponse.json({ success: false, error: 'User exists' }, { status: 400 });
   }
-  await db.collection('users').insertOne({ username, password });
+  await User.create({ username, password });
   return NextResponse.json({ success: true });
 }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import connect from '../../../utils/mongoose';
+import User from '../../../models/User';
+
+export async function GET(request: Request) {
+  const role = request.headers.get('x-role');
+  if (role !== 'super-admin') {
+    return NextResponse.json({ success: false }, { status: 403 });
+  }
+  await connect();
+  const users = await User.find({}, { _id: 0, username: 1, role: 1 });
+  return NextResponse.json({ users });
+}
+
+export async function PUT(request: Request) {
+  const roleHeader = request.headers.get('x-role');
+  if (roleHeader !== 'super-admin') {
+    return NextResponse.json({ success: false }, { status: 403 });
+  }
+  const { username, role } = await request.json();
+  await connect();
+  await User.updateOne({ username }, { role });
+  return NextResponse.json({ success: true });
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -16,6 +16,7 @@ export default function LoginPage() {
       const res = await axios.post('/api/login', { username, password });
       if (res.data.success) {
         localStorage.setItem('loggedIn', 'true');
+        localStorage.setItem('role', res.data.role);
         router.push('/');
       }
     } catch (e: any) {

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
+import { Container, Typography, Table, TableHead, TableRow, TableCell, TableBody, Select, MenuItem } from '@mui/material';
+
+interface User {
+  username: string;
+  role: string;
+}
+
+export default function ManagePage() {
+  const router = useRouter();
+  const [users, setUsers] = useState<User[]>([]);
+
+  useEffect(() => {
+    const role = localStorage.getItem('role');
+    if (role !== 'super-admin') {
+      router.push('/');
+      return;
+    }
+    fetchUsers(role);
+  }, [router]);
+
+  const fetchUsers = async (role: string | null) => {
+    const res = await axios.get('/api/users', { headers: { 'x-role': role || '' } });
+    setUsers(res.data.users);
+  };
+
+  const handleRoleChange = async (username: string, newRole: string) => {
+    const role = localStorage.getItem('role');
+    await axios.put('/api/users', { username, role: newRole }, { headers: { 'x-role': role || '' } });
+    setUsers(prev => prev.map(u => u.username === username ? { ...u, role: newRole } : u));
+  };
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Typography variant="h5" gutterBottom>Role Management</Typography>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Username</TableCell>
+            <TableCell>Role</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {users.map(u => (
+            <TableRow key={u.username}>
+              <TableCell>{u.username}</TableCell>
+              <TableCell>
+                <Select value={u.role} onChange={e => handleRoleChange(u.username, e.target.value as string)}>
+                  <MenuItem value="super-admin">super-admin</MenuItem>
+                  <MenuItem value="admin">admin</MenuItem>
+                  <MenuItem value="member">member</MenuItem>
+                </Select>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Container>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,6 +38,7 @@ const Home: React.FC = () => {
   const handleLogout = async () => {
     await axios.post('/api/logout');
     localStorage.removeItem('loggedIn');
+    localStorage.removeItem('role');
     window.location.href = '/login';
   };
 

--- a/models/Club.ts
+++ b/models/Club.ts
@@ -1,0 +1,7 @@
+import { Schema, model, models } from 'mongoose';
+
+const clubSchema = new Schema({
+  name: { type: String, required: true },
+});
+
+export default models.Club || model('Club', clubSchema);

--- a/models/User.ts
+++ b/models/User.ts
@@ -1,0 +1,13 @@
+import { Schema, model, models } from 'mongoose';
+
+const userSchema = new Schema({
+  username: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  role: {
+    type: String,
+    enum: ['super-admin', 'admin', 'member'],
+    default: 'member',
+  },
+});
+
+export default models.User || model('User', userSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/x-data-grid": "^7.10.0",
         "axios": "^1.7.2",
         "mongodb": "^6.17.0",
+        "mongoose": "^8.0.0",
         "next": "14.2.5",
         "react": "^18",
         "react-dom": "^18"
@@ -3910,6 +3911,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4133,6 +4143,101 @@
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.15.2",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.15.2.tgz",
+      "integrity": "sha512-GLwghI2dS/n5BTBljspF4+FsCEBeHgnMQyX8GloYkLkl+MKljKkjcP9DhLr47Yod2RO1RCr4vZ3evUZAyuoILw==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.10.3",
+        "kareem": "2.6.3",
+        "mongodb": "~6.16.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/mongodb": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
+      "integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.3",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongoose/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -5137,6 +5242,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mui/x-data-grid": "^7.10.0",
     "axios": "^1.7.2",
     "mongodb": "^6.17.0",
+    "mongoose": "^8.0.0",
     "next": "14.2.5",
     "react": "^18",
     "react-dom": "^18"

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1,13 +1,13 @@
 import { MongoClient, ServerApiVersion } from 'mongodb';
 
 const uri = process.env.DB_URL;
-if (!uri) {
-  throw new Error('DB_URL environment variable is not set');
-}
 
 let client: MongoClient | null = null;
 
 export async function getClient() {
+  if (!uri) {
+    throw new Error('DB_URL environment variable is not set');
+  }
   if (!client) {
     client = new MongoClient(uri, {
       serverApi: {

--- a/utils/mongoose.ts
+++ b/utils/mongoose.ts
@@ -1,0 +1,21 @@
+import mongoose from 'mongoose';
+
+const uri = process.env.DB_URL;
+
+let cached: { conn: typeof mongoose | null; promise: Promise<typeof mongoose> | null } = (global as any).mongoose;
+
+if (!cached) {
+  cached = (global as any).mongoose = { conn: null, promise: null };
+}
+
+export default async function connect() {
+  if (!uri) {
+    throw new Error('DB_URL environment variable is not set');
+  }
+  if (cached.conn) return cached.conn;
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(uri, { bufferCommands: false });
+  }
+  cached.conn = await cached.promise;
+  return cached.conn;
+}


### PR DESCRIPTION
## Summary
- introduce Mongoose connection and models
- migrate login/signup APIs to Mongoose
- add `/api/users` route for updating user roles
- create `/manage` page for super-admin role management
- store user role in localStorage and clear on logout
- document new role management page and DB_URL usage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d1a34d3c88322a958de072f816070