### PR TITLE
Fix strict populate error

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -9,7 +9,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ success: false }, { status: 400 });
   }
   await connect();
-  const user = await User.findOne({ username }).populate('club');
+  const user = await User.findOne({ username }).populate({ path: 'club', strictPopulate: false });
   if (!user) {
     return NextResponse.json({ success: false }, { status: 404 });
   }


### PR DESCRIPTION
## Summary
- disable strictPopulate on club query for profile API

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2a70e82083228404909b0bfdff2b