### PR TITLE
Add app bar and public home page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import AppBar from "../components/AppBar";
 
 
 export const metadata: Metadata = {
@@ -17,7 +18,10 @@ export default function RootLayout({
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
-      <body>{children}</body>
+      <body>
+        <AppBar />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,20 @@
-'use client';
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+'use client'
+import Link from 'next/link'
+import { Button } from '../components/ui/button'
 
 export default function Home() {
-  const router = useRouter();
-  useEffect(() => {
-    const loggedIn = localStorage.getItem('loggedIn');
-    if (loggedIn) {
-      router.replace('/profile');
-    } else {
-      router.replace('/login');
-    }
-  }, [router]);
-  return null;
+  return (
+    <div className="flex flex-col items-center justify-center py-10 space-y-4">
+      <h1 className="text-3xl font-bold">Welcome to Game Planer</h1>
+      <p className="text-center">Plan games for our lovely PIV Club members.</p>
+      <div className="space-x-4">
+        <Button asChild>
+          <Link href="/login">Login</Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/signup">Sign Up</Link>
+        </Button>
+      </div>
+    </div>
+  )
 }

--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import axios from 'axios'
+import { Button } from './ui/button'
+
+export default function AppBar() {
+  const router = useRouter()
+  const [loggedIn, setLoggedIn] = useState(false)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setLoggedIn(localStorage.getItem('loggedIn') === 'true')
+    }
+  }, [])
+
+  const handleLogout = async () => {
+    try {
+      await axios.post('/api/logout')
+    } catch (e) {
+      // ignore errors
+    }
+    localStorage.removeItem('loggedIn')
+    localStorage.removeItem('role')
+    localStorage.removeItem('username')
+    setLoggedIn(false)
+    router.push('/')
+  }
+
+  return (
+    <nav className="flex items-center justify-between bg-gray-100 border-b px-4 py-2">
+      <Link href="/" className="font-semibold">Game Planer</Link>
+      <div className="space-x-4 flex items-center">
+        <Link href="/" className="hover:underline">Home</Link>
+        {loggedIn && (
+          <Link href="/profile" className="hover:underline">Profile</Link>
+        )}
+        {!loggedIn && (
+          <Link href="/login" className="hover:underline">Login</Link>
+        )}
+        {!loggedIn && (
+          <Link href="/signup" className="hover:underline">Sign Up</Link>
+        )}
+        {loggedIn && (
+          <Button variant="ghost" onClick={handleLogout} className="px-2 py-1 h-auto">Logout</Button>
+        )}
+      </div>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add navigation bar with login/logout
- mount navigation in the root layout
- replace redirect page with a simple home page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684db363cb2083229363673267ace173