### PR TITLE
Integrate better-auth for Google login

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/deploym
 ## Local Environment Setup
 
 1. Create a `.env.local` file in the root of the project.
-2. Inside that file, define the `DB_URL` variable with your MongoDB connection string used by Mongoose:
+2. Inside that file, define the `DB_URL` variable with your MongoDB connection string used by Mongoose, and the credentials for Google OAuth:
 
    ```env
    DB_URL=your_mongodb_connection_string
+   GOOGLE_CLIENT_ID=your_google_client_id
+   GOOGLE_CLIENT_SECRET=your_google_client_secret
    ```
 
 3. Run the development server with `npm run dev`.

--- a/app/api/auth/[...route]/route.ts
+++ b/app/api/auth/[...route]/route.ts
@@ -1,0 +1,11 @@
+import { getAuthHandler } from '../../../../lib/auth';
+
+export async function GET(request: Request) {
+  const handler = await getAuthHandler();
+  return handler.GET(request);
+}
+
+export async function POST(request: Request) {
+  const handler = await getAuthHandler();
+  return handler.POST(request);
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -8,17 +8,19 @@ import { Input } from '../../components/ui/input';
 
 export default function LoginPage() {
   const router = useRouter();
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
   const handleSubmit = async () => {
     try {
-      const res = await axios.post('/api/login', { username, password });
+      const res = await axios.post('/api/auth/sign-in/email', { email, password });
       if (res.data.success) {
         localStorage.setItem('loggedIn', 'true');
-        localStorage.setItem('role', res.data.role);
-        localStorage.setItem('username', username);
+        const session = await axios.get('/api/auth/get-session?disableRefresh=true');
+        const role = session.data?.session?.user?.role;
+        if (role) localStorage.setItem('role', role);
+        localStorage.setItem('username', email);
         router.push('/profile');
       }
     } catch (e: any) {
@@ -26,14 +28,22 @@ export default function LoginPage() {
     }
   };
 
+  const handleGoogleLogin = async () => {
+    const res = await axios.post('/api/auth/sign-in/social', { provider: 'google' });
+    if (res.data.redirect && res.data.url) {
+      window.location.href = res.data.url;
+    }
+  };
+
   return (
     <div className="mx-auto max-w-xs py-8">
       <h1 className="text-2xl font-semibold mb-4">Login</h1>
       <div className="space-y-4">
-        <Input placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <Input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
         <Input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
         {error && <p className="text-red-500 text-sm">{error}</p>}
         <Button className="w-full" onClick={handleSubmit}>Login</Button>
+        <Button className="w-full" variant="secondary" onClick={handleGoogleLogin}>Login with Google</Button>
         <Button variant="outline" className="w-full" asChild>
           <Link href="/signup">Sign Up</Link>
         </Button>

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -24,12 +24,14 @@ export default function ManagePage() {
   const [eventName, setEventName] = useState('');
 
   useEffect(() => {
-    const role = localStorage.getItem('role');
-    if (role !== 'super-admin') {
-      router.push('/');
-      return;
-    }
-    fetchUsers(role);
+    axios.get('/api/auth/get-session?disableRefresh=true').then(res => {
+      const role = res.data?.session?.user?.role;
+      if (role !== 'super-admin') {
+        router.push('/');
+        return;
+      }
+      fetchUsers(role);
+    });
   }, [router]);
 
   const fetchUsers = async (role: string | null) => {
@@ -38,32 +40,23 @@ export default function ManagePage() {
   };
 
   const handleRoleChange = async (username: string, newRole: string) => {
-    const role = localStorage.getItem('role');
-    await axios.put(
-      '/api/users',
-      { username, role: newRole },
-      { headers: { 'x-role': role || '' } }
-    );
+    const { data } = await axios.get('/api/auth/get-session?disableRefresh=true');
+    const role = data?.session?.user?.role;
+    await axios.put('/api/users', { username, role: newRole }, { headers: { 'x-role': role || '' } });
     setUsers(prev => prev.map(u => (u.username === username ? { ...u, role: newRole } : u)));
   };
 
   const handleCreateClub = async () => {
-    const role = localStorage.getItem('role');
-    await axios.post(
-      '/api/clubs',
-      { name: clubName },
-      { headers: { 'x-role': role || '' } }
-    );
+    const { data } = await axios.get('/api/auth/get-session?disableRefresh=true');
+    const role = data?.session?.user?.role;
+    await axios.post('/api/clubs', { name: clubName }, { headers: { 'x-role': role || '' } });
     setClubName('');
   };
 
   const handleCreateEvent = async () => {
-    const role = localStorage.getItem('role');
-    await axios.post(
-      '/api/events',
-      { name: eventName },
-      { headers: { 'x-role': role || '' } }
-    );
+    const { data } = await axios.get('/api/auth/get-session?disableRefresh=true');
+    const role = data?.session?.user?.role;
+    await axios.post('/api/events', { name: eventName }, { headers: { 'x-role': role || '' } });
     setEventName('');
   };
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -4,9 +4,8 @@ import { useRouter } from 'next/navigation';
 import axios from 'axios';
 
 interface ProfileData {
-  username: string;
-  role: string;
-  club: string | null;
+  email: string;
+  name?: string | null;
 }
 
 export default function ProfilePage() {
@@ -14,15 +13,13 @@ export default function ProfilePage() {
   const [data, setData] = useState<ProfileData | null>(null);
 
   useEffect(() => {
-    const loggedIn = localStorage.getItem('loggedIn');
-    const username = localStorage.getItem('username');
-    if (!loggedIn || !username) {
-      router.push('/login');
-      return;
-    }
-    axios
-      .get('/api/profile', { headers: { 'x-username': username } })
-      .then(res => setData(res.data));
+    axios.get('/api/auth/get-session?disableRefresh=true').then(res => {
+      if (!res.data || !res.data.session) {
+        router.push('/login');
+        return;
+      }
+      setData(res.data.session.user);
+    });
   }, [router]);
 
   if (!data) return <div className="p-4">Loading...</div>;
@@ -30,9 +27,8 @@ export default function ProfilePage() {
   return (
     <div className="p-4 space-y-2">
       <h1 className="text-2xl mb-4">Profile</h1>
-      <p><strong>Username:</strong> {data.username}</p>
-      <p><strong>Role:</strong> {data.role}</p>
-      <p><strong>Club:</strong> {data.club || 'None'}</p>
+      <p><strong>Email:</strong> {data.email}</p>
+      {data.name && <p><strong>Name:</strong> {data.name}</p>}
     </div>
   );
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -8,7 +8,7 @@ import { Input } from '../../components/ui/input';
 
 export default function SignupPage() {
   const router = useRouter();
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
@@ -19,7 +19,7 @@ export default function SignupPage() {
       return;
     }
     try {
-      const res = await axios.post('/api/signup', { username, password });
+      const res = await axios.post('/api/auth/sign-up/email', { email, password });
       if (res.data.success) {
         router.push('/login');
       }
@@ -32,7 +32,7 @@ export default function SignupPage() {
     <div className="mx-auto max-w-xs py-8">
       <h1 className="text-2xl font-semibold mb-4">Sign Up</h1>
       <div className="space-y-4">
-        <Input placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <Input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
         <Input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
         <Input type="password" placeholder="Confirm Password" value={confirmPassword} onChange={e => setConfirmPassword(e.target.value)} />
         {error && <p className="text-red-500 text-sm">{error}</p>}

--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -13,21 +13,21 @@ export default function AppBar() {
   const [menuOpen, setMenuOpen] = useState(false)
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setLoggedIn(localStorage.getItem('loggedIn') === 'true')
-      setRole(localStorage.getItem('role') || '')
-    }
+    axios.get('/api/auth/get-session?disableRefresh=true').then(res => {
+      const user = res.data?.session?.user
+      if (user) {
+        setLoggedIn(true)
+        setRole(user.role || '')
+      }
+    })
   }, [])
 
   const handleLogout = async () => {
     try {
-      await axios.post('/api/logout')
+      await axios.post('/api/auth/sign-out')
     } catch (e) {
       // ignore errors
     }
-    localStorage.removeItem('loggedIn')
-    localStorage.removeItem('role')
-    localStorage.removeItem('username')
     setLoggedIn(false)
     router.push('/')
   }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,29 @@
+import { betterAuth } from 'better-auth';
+import { mongodbAdapter } from 'better-auth/adapters/mongodb';
+import { google } from 'better-auth/social-providers';
+import { nextCookies, toNextJsHandler } from 'better-auth/integrations/next-js';
+import { getClient } from '../utils/db';
+
+let handler: ReturnType<typeof toNextJsHandler> | null = null;
+
+async function getHandler() {
+  if (!handler) {
+    const client = await getClient();
+    const auth = betterAuth({
+      adapter: mongodbAdapter(client.db()),
+      socialProviders: [
+        google({
+          clientId: process.env.GOOGLE_CLIENT_ID || '',
+          clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+        }),
+      ],
+      plugins: [nextCookies()],
+    });
+    handler = toNextJsHandler(auth);
+  }
+  return handler!;
+}
+
+export async function getAuthHandler() {
+  return getHandler();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.0.2",
         "axios": "^1.7.2",
+        "better-auth": "^1.2.9",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "lucide-react": "^0.386.0",
@@ -43,6 +44,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@better-auth/utils": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.2.5.tgz",
+      "integrity": "sha512-uI2+/8h/zVsH8RrYdG8eUErbuGBk16rZKQfz8CjxQOyCE6v7BqFYEbFwvOkvl1KbUdxhqOnXp78+uE5h8qVEgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^5.8.2",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@better-fetch/fetch": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.18.tgz",
+      "integrity": "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -136,6 +152,12 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
+    },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -264,6 +286,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.3.0",
@@ -423,6 +451,27 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.6.0.tgz",
+      "integrity": "sha512-mIbq/R9QXk5/cTfESb1OKtyFnk7oc1Om/8onA1158K9/OZUQFDEVy55jVTato+xmp3XX6F6Qh0zz0Nc1AxAlRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -456,6 +505,64 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.3.16",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.3.16.tgz",
+      "integrity": "sha512-a1viIv3bIahXNssrOIkXZIlI2ePpZaNmR30d4aBL99mu2rO+mT9D6zBsp7H6eROWGtmwv0Ionp5olJurIo09dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.15.tgz",
+      "integrity": "sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.15.tgz",
+      "integrity": "sha512-p6hsanvPhexRtYSOHihLvUUgrJ8y0FtOM97N5UEpC+VifFYyZa0iZ5cXjTkZoDwxJ/TTJ1IJo3HVTB2JJTpXvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.15.tgz",
+      "integrity": "sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.15.tgz",
+      "integrity": "sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -970,6 +1077,30 @@
       "integrity": "sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==",
       "dev": true
     },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.1.0.tgz",
+      "integrity": "sha512-WuHZ/PYvyPJ9nxSzgHtOEjogBhwJfC8xzYkPC+rR/+8chl/ft4ngjiK8kSU5HtRJfczupyOh33b25TjYbvwAcg==",
+      "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.1.1.tgz",
+      "integrity": "sha512-1hsLpRHfSuMB9ee2aAdh0Htza/X3f4djhYISrggqGe3xopNjOcePiSDkDDoPzDYaaMCrbqGP1H2TYU7bgL9PmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -1456,6 +1587,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
+      "integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -1515,6 +1660,37 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/better-auth": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.2.9.tgz",
+      "integrity": "sha512-WLqBXDzuaCQetQctLGC5oTfGmL32zUvxnM4Y+LZkhwseMaZWq5EKI+c/ZATgz2YkFt7726q659PF8CfB9P1VuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/utils": "0.2.5",
+        "@better-fetch/fetch": "^1.1.18",
+        "@noble/ciphers": "^0.6.0",
+        "@noble/hashes": "^1.6.1",
+        "@simplewebauthn/browser": "^13.0.0",
+        "@simplewebauthn/server": "^13.0.0",
+        "better-call": "^1.0.8",
+        "defu": "^6.1.4",
+        "jose": "^5.9.6",
+        "kysely": "^0.28.2",
+        "nanostores": "^0.11.3",
+        "zod": "^3.24.1"
+      }
+    },
+    "node_modules/better-call": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.0.9.tgz",
+      "integrity": "sha512-Qfm0gjk0XQz0oI7qvTK1hbqTsBY4xV2hsHAxF8LZfUYl3RaECCIifXuVqtPpZJWvlCCMlQSvkvhhyuApGUba6g==",
+      "dependencies": {
+        "@better-fetch/fetch": "^1.1.4",
+        "rou3": "^0.5.1",
+        "set-cookie-parser": "^2.7.1",
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1923,6 +2099,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -3602,6 +3784,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3680,6 +3871,15 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kysely": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.2.tgz",
+      "integrity": "sha512-4YAVLoF0Sf0UTqlhgQMFU9iQECdah7n+13ANkiuVfRvlK+uI0Etbgd7bVP36dKlG+NXWbhGua8vnGt+sdhvT7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -4034,6 +4234,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanostores": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.11.4.tgz",
+      "integrity": "sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/natural-compare": {
@@ -4632,6 +4847,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4892,6 +5125,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rou3": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.5.1.tgz",
+      "integrity": "sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ==",
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4969,6 +5208,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5507,9 +5752,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5609,10 +5855,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
-      "dev": true,
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5635,6 +5881,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
@@ -5947,6 +6199,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.64",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
+      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.0.2",
     "axios": "^1.7.2",
+    "better-auth": "^1.2.9",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "lucide-react": "^0.386.0",


### PR DESCRIPTION
## Summary
- add `better-auth` dependency
- set up Better Auth with Google OAuth
- expose Better Auth API routes
- adapt login and signup pages to new auth
- update profile and management pages to use session API
- update AppBar to sign out via Better Auth
- document Google OAuth env vars in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dbb3d8a908322b26300edf6185354