### PR TITLE
Implement club management features

### DIFF
--- a/app/api/clubs/[id]/members/route.ts
+++ b/app/api/clubs/[id]/members/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import connect from '../../../../../utils/mongoose';
+import User from '../../../../../models/User';
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+  const role = request.headers.get('x-role');
+  const reqUser = request.headers.get('x-username');
+  const { username } = await request.json();
+  await connect();
+  if (role === 'super-admin') {
+    await User.updateOne({ username }, { club: params.id });
+    return NextResponse.json({ success: true });
+  }
+  if (role === 'admin') {
+    const admin = await User.findOne({ username: reqUser });
+    if (admin && admin.club && admin.club.toString() === params.id) {
+      await User.updateOne({ username }, { club: params.id });
+      return NextResponse.json({ success: true });
+    }
+  }
+  return NextResponse.json({ success: false }, { status: 403 });
+}
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  const role = request.headers.get('x-role');
+  const reqUser = request.headers.get('x-username');
+  const { username } = await request.json();
+  await connect();
+  if (role === 'super-admin') {
+    await User.updateOne({ username }, { $unset: { club: 1 } });
+    return NextResponse.json({ success: true });
+  }
+  if (role === 'admin') {
+    const admin = await User.findOne({ username: reqUser });
+    if (admin && admin.club && admin.club.toString() === params.id) {
+      await User.updateOne({ username }, { $unset: { club: 1 } });
+      return NextResponse.json({ success: true });
+    }
+  }
+  return NextResponse.json({ success: false }, { status: 403 });
+}

--- a/app/api/clubs/[id]/route.ts
+++ b/app/api/clubs/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import connect from '../../../../utils/mongoose';
+import Club from '../../../../models/Club';
+import User from '../../../../models/User';
+import Event from '../../../../models/Event';
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  await connect();
+  const club = await Club.findById(params.id);
+  if (!club) return NextResponse.json({ success: false }, { status: 404 });
+  const members = await User.find({ club: params.id }, { _id: 0, username: 1 });
+  const events = await Event.find({ club: params.id }, { _id: 0, name: 1 });
+  return NextResponse.json({
+    id: club._id,
+    name: club.name,
+    members: members.map(m => m.username),
+    events: events.map(e => e.name),
+  });
+}
+
+export async function PUT(request: Request, { params }: { params: { id: string } }) {
+  const role = request.headers.get('x-role');
+  const username = request.headers.get('x-username');
+  const { name } = await request.json();
+  await connect();
+  if (role === 'super-admin') {
+    await Club.updateOne({ _id: params.id }, { name });
+    return NextResponse.json({ success: true });
+  }
+  if (role === 'admin') {
+    const admin = await User.findOne({ username });
+    if (admin && admin.club && admin.club.toString() === params.id) {
+      await Club.updateOne({ _id: params.id }, { name });
+      return NextResponse.json({ success: true });
+    }
+  }
+  return NextResponse.json({ success: false }, { status: 403 });
+}

--- a/app/api/clubs/route.ts
+++ b/app/api/clubs/route.ts
@@ -4,7 +4,7 @@ import Club from '../../../models/Club';
 
 export async function GET() {
   await connect();
-  const clubs = await Club.find({}, { _id: 0, name: 1 });
+  const clubs = await Club.find({}, { name: 1 });
   return NextResponse.json({ clubs });
 }
 

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -17,5 +17,6 @@ export async function GET(request: Request) {
     username: user.username,
     role: user.role,
     club: user.club ? (user.club as any).name : null,
+    clubId: user.club ? (user.club as any)._id : null,
   });
 }

--- a/app/club-manage/page.tsx
+++ b/app/club-manage/page.tsx
@@ -1,0 +1,111 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
+import { Input } from '../../components/ui/input';
+import { Button } from '../../components/ui/button';
+
+interface ClubData {
+  id: string;
+  name: string;
+  members: string[];
+  events: string[];
+}
+
+export default function ClubManage() {
+  const router = useRouter();
+  const [role, setRole] = useState('');
+  const [username, setUsername] = useState('');
+  const [club, setClub] = useState<ClubData | null>(null);
+  const [newName, setNewName] = useState('');
+  const [newMember, setNewMember] = useState('');
+  const [newEvent, setNewEvent] = useState('');
+
+  useEffect(() => {
+    axios.get('/api/auth/get-session?disableRefresh=true').then(async res => {
+      const r = res.data?.session?.user?.role;
+      const u = res.data?.session?.user?.email;
+      if (!r || (r !== 'admin' && r !== 'super-admin')) {
+        router.push('/');
+        return;
+      }
+      setRole(r);
+      setUsername(u);
+      const prof = await axios.get('/api/profile', { headers: { 'x-username': u } });
+      if (!prof.data.club) {
+        router.push('/');
+        return;
+      }
+      const c = await axios.get(`/api/clubs/${prof.data.clubId || prof.data.club}`);
+      setClub(c.data);
+      setNewName(c.data.name);
+    });
+  }, [router]);
+
+  if (!club) return <div className="p-4">Loading...</div>;
+
+  const headers = { 'x-role': role, 'x-username': username };
+
+  const updateName = async () => {
+    await axios.put(`/api/clubs/${club.id}`, { name: newName }, { headers });
+    setClub({ ...club, name: newName });
+  };
+
+  const addMember = async () => {
+    await axios.post(`/api/clubs/${club.id}/members`, { username: newMember }, { headers });
+    setClub({ ...club, members: [...club.members, newMember] });
+    setNewMember('');
+  };
+
+  const removeMember = async (m: string) => {
+    await axios.delete(`/api/clubs/${club.id}/members`, { data: { username: m }, headers });
+    setClub({ ...club, members: club.members.filter(x => x !== m) });
+  };
+
+  const makeAdmin = async (m: string) => {
+    await axios.put('/api/users', { username: m, role: 'admin' }, { headers });
+  };
+
+  const createEvent = async () => {
+    await axios.post('/api/events', { name: newEvent, clubId: club.id }, { headers });
+    const evRes = await axios.get(`/api/events?clubId=${club.id}`);
+    setClub({ ...club, events: evRes.data.events.map((e: any) => e.name) });
+    setNewEvent('');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Manage {club.name}</h1>
+      <div className="space-x-2">
+        <Input value={newName} onChange={e => setNewName(e.target.value)} />
+        <Button onClick={updateName}>Change Name</Button>
+      </div>
+      <div className="space-x-2">
+        <Input placeholder="New Member" value={newMember} onChange={e => setNewMember(e.target.value)} />
+        <Button onClick={addMember}>Add Member</Button>
+      </div>
+      <div>
+        <h2 className="text-xl mb-2">Members</h2>
+        <ul className="list-disc ml-4 space-y-1">
+          {club.members.map(m => (
+            <li key={m} className="flex items-center space-x-2">
+              <span>{m}</span>
+              <Button size="sm" onClick={() => removeMember(m)}>Kick</Button>
+              <Button size="sm" variant="secondary" onClick={() => makeAdmin(m)}>Make Admin</Button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="space-x-2">
+        <Input placeholder="New Event" value={newEvent} onChange={e => setNewEvent(e.target.value)} />
+        <Button onClick={createEvent}>Create Event</Button>
+      </div>
+      <div>
+        <h2 className="text-xl mb-2">Events</h2>
+        <ul className="list-disc ml-4">
+          {club.events.map(e => <li key={e}>{e}</li>)}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/app/club/[id]/page.tsx
+++ b/app/club/[id]/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+interface ClubData {
+  id: string;
+  name: string;
+  members: string[];
+  events: string[];
+}
+
+export default function ClubHome({ params }: { params: { id: string } }) {
+  const [data, setData] = useState<ClubData | null>(null);
+
+  useEffect(() => {
+    axios.get(`/api/clubs/${params.id}`).then(res => setData(res.data));
+  }, [params.id]);
+
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">{data.name}</h1>
+      <div>
+        <h2 className="text-xl mb-2">Members</h2>
+        <ul className="list-disc ml-4">
+          {data.members.map(m => <li key={m}>{m}</li>)}
+        </ul>
+      </div>
+      <div>
+        <h2 className="text-xl mb-2">Events</h2>
+        <ul className="list-disc ml-4">
+          {data.events.map(e => <li key={e}>{e}</li>)}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -22,6 +22,8 @@ export default function ManagePage() {
   const [users, setUsers] = useState<User[]>([]);
   const [clubName, setClubName] = useState('');
   const [eventName, setEventName] = useState('');
+  const [clubs, setClubs] = useState<{ id: string; name: string }[]>([]);
+  const [clubEdits, setClubEdits] = useState<{ [id: string]: string }>({});
 
   useEffect(() => {
     axios.get('/api/auth/get-session?disableRefresh=true').then(res => {
@@ -31,12 +33,18 @@ export default function ManagePage() {
         return;
       }
       fetchUsers(role);
+      fetchClubs(role);
     });
   }, [router]);
 
   const fetchUsers = async (role: string | null) => {
     const res = await axios.get('/api/users', { headers: { 'x-role': role || '' } });
     setUsers(res.data.users);
+  };
+
+  const fetchClubs = async (role: string | null) => {
+    const res = await axios.get('/api/clubs');
+    setClubs(res.data.clubs.map((c: any) => ({ id: c._id, name: c.name })));
   };
 
   const handleRoleChange = async (username: string, newRole: string) => {
@@ -51,6 +59,7 @@ export default function ManagePage() {
     const role = data?.session?.user?.role;
     await axios.post('/api/clubs', { name: clubName }, { headers: { 'x-role': role || '' } });
     setClubName('');
+    fetchClubs(role);
   };
 
   const handleCreateEvent = async () => {
@@ -99,6 +108,27 @@ export default function ManagePage() {
         <div className="flex items-center space-x-2">
           <Input placeholder="New Club Name" value={clubName} onChange={e => setClubName(e.target.value)} />
           <Button onClick={handleCreateClub}>Create Club</Button>
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold mb-2">Edit Clubs</h2>
+          <div className="space-y-2">
+            {clubs.map(c => (
+              <div key={c.id} className="flex items-center space-x-2">
+                <Input
+                  value={clubEdits[c.id] ?? c.name}
+                  onChange={e => setClubEdits(p => ({ ...p, [c.id]: e.target.value }))}
+                />
+                <Button
+                  onClick={async () => {
+                    const { data } = await axios.get('/api/auth/get-session?disableRefresh=true');
+                    const role = data?.session?.user?.role;
+                    await axios.put(`/api/clubs/${c.id}`, { name: clubEdits[c.id] ?? c.name }, { headers: { 'x-role': role || '' } });
+                    fetchClubs(role);
+                  }}
+                >Update</Button>
+              </div>
+            ))}
+          </div>
         </div>
         <div className="flex items-center space-x-2">
           <Input placeholder="New Event Name" value={eventName} onChange={e => setEventName(e.target.value)} />

--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -11,13 +11,16 @@ export default function AppBar() {
   const [loggedIn, setLoggedIn] = useState(false)
   const [role, setRole] = useState('')
   const [menuOpen, setMenuOpen] = useState(false)
+  const [clubId, setClubId] = useState<string | null>(null)
 
   useEffect(() => {
-    axios.get('/api/auth/get-session?disableRefresh=true').then(res => {
+    axios.get('/api/auth/get-session?disableRefresh=true').then(async res => {
       const user = res.data?.session?.user
       if (user) {
         setLoggedIn(true)
         setRole(user.role || '')
+        const prof = await axios.get('/api/profile', { headers: { 'x-username': user.email } })
+        if (prof.data.clubId) setClubId(prof.data.clubId)
       }
     })
   }, [])
@@ -46,6 +49,12 @@ export default function AppBar() {
                   <Link href="/profile" onClick={() => setMenuOpen(false)} className="block px-4 py-2 hover:bg-gray-100">Profile</Link>
                   {role === 'super-admin' && (
                     <Link href="/manage" onClick={() => setMenuOpen(false)} className="block px-4 py-2 hover:bg-gray-100">Manage</Link>
+                  )}
+                  {clubId && (
+                    <Link href={`/club/${clubId}`} onClick={() => setMenuOpen(false)} className="block px-4 py-2 hover:bg-gray-100">Club Home</Link>
+                  )}
+                  {clubId && (role === 'admin' || role === 'super-admin') && (
+                    <Link href="/club-manage" onClick={() => setMenuOpen(false)} className="block px-4 py-2 hover:bg-gray-100">Club Manage</Link>
                   )}
                   {(role === 'admin' || role === 'super-admin') && (
                     <Link href="/event-edit" onClick={() => setMenuOpen(false)} className="block px-4 py-2 hover:bg-gray-100">Event Edit</Link>

--- a/models/Event.ts
+++ b/models/Event.ts
@@ -2,6 +2,7 @@ import { Schema, model, models } from 'mongoose';
 
 const eventSchema = new Schema({
   name: { type: String, required: true },
+  club: { type: Schema.Types.ObjectId, ref: 'Club' },
 });
 
 export default models.Event || model('Event', eventSchema);


### PR DESCRIPTION
## Summary
- add club CRUD utilities for admins and super-admins
- list & update clubs in Manage page
- display a club home page with members and events
- add club manage page for admins
- expose club info via new API routes
- link club pages from AppBar

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684dcb691c5883228725c8e4dae8977d