### PR TITLE
Add global auth context

### DIFF
--- a/app/event-edit/page.tsx
+++ b/app/event-edit/page.tsx
@@ -6,8 +6,13 @@ import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Textarea } from '../../components/ui/textarea';
 import { Trash2 } from 'lucide-react';
+import { useAuth } from '../../components/AuthProvider';
+import { useRouter } from 'next/navigation';
 
 const Home: React.FC = () => {
+
+  const { user, loading, refresh } = useAuth();
+  const router = useRouter();
 
   const [teamAPlayers, setTeamAPlayers] = useState<string>('');
   const [teamBPlayers, setTeamBPlayers] = useState<string>('');
@@ -22,8 +27,9 @@ const Home: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && !localStorage.getItem('loggedIn')) {
-      window.location.href = '/login';
+    if (!loading && !user) {
+      router.push('/login');
+      return;
     }
     const savedSchedule = localStorage.getItem('schedule');
     const savedScores = localStorage.getItem('scores');
@@ -33,13 +39,12 @@ const Home: React.FC = () => {
     if (savedScores) {
       setScores(JSON.parse(savedScores));
     }
-  }, []);
+  }, [user, loading, router]);
 
   const handleLogout = async () => {
     await axios.post('/api/logout');
-    localStorage.removeItem('loggedIn');
-    localStorage.removeItem('role');
-    window.location.href = '/login';
+    await refresh();
+    router.push('/login');
   };
 
   const handlePlayerListChange = (team: 'A' | 'B', value: string) => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import AppBar from "../components/AppBar";
+import { AuthProvider } from "../components/AuthProvider";
 
 
 export const metadata: Metadata = {
@@ -19,8 +20,10 @@ export default function RootLayout({
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
       <body>
-        <AppBar />
-        {children}
+        <AuthProvider>
+          <AppBar />
+          {children}
+        </AuthProvider>
       </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -5,9 +5,11 @@ import axios from 'axios';
 import Link from 'next/link';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
+import { useAuth } from '../../components/AuthProvider';
 
 export default function LoginPage() {
   const router = useRouter();
+  const { refresh } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -16,11 +18,7 @@ export default function LoginPage() {
     try {
       const res = await axios.post('/api/auth/sign-in/email', { email, password });
       if (res.data.success) {
-        localStorage.setItem('loggedIn', 'true');
-        const session = await axios.get('/api/auth/get-session?disableRefresh=true');
-        const role = session.data?.session?.user?.role;
-        if (role) localStorage.setItem('role', role);
-        localStorage.setItem('username', email);
+        await refresh();
         router.push('/profile');
       }
     } catch (e: any) {

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -4,32 +4,28 @@ import { useRouter } from "next/navigation";
 import axios from "axios";
 import { Input } from "../../components/ui/input";
 import { Button } from "../../components/ui/button";
+import { useAuth } from "../../components/AuthProvider";
 
 export default function OnboardingPage() {
   const router = useRouter();
+  const { user, loading } = useAuth();
   const [username, setUsername] = useState("");
   const [name, setName] = useState("");
   const [error, setError] = useState("");
 
   useEffect(() => {
-    axios.get("/api/auth/get-session?disableRefresh=true").then((res) => {
-      if (!res.data || !res.data.session) {
-        router.push("/login");
-      }
-    });
-  }, [router]);
+    if (!loading && !user) {
+      router.push("/login");
+    }
+  }, [loading, user, router]);
 
   const handleSubmit = async () => {
     try {
-      const session = await axios.get(
-        "/api/auth/get-session?disableRefresh=true",
-      );
-      const email = session.data?.session?.user?.email;
-      if (!email) {
+      if (!user?.email) {
         router.push("/login");
         return;
       }
-      await axios.post("/api/meta", { email, username, name });
+      await axios.post("/api/meta", { email: user.email, username, name });
       router.push("/profile");
     } catch (e) {
       setError("Failed to save profile");

--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -1,34 +1,24 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import axios from 'axios'
 import { Button } from './ui/button'
+import { useAuth } from './AuthProvider'
 
 export default function AppBar() {
   const router = useRouter()
-  const [loggedIn, setLoggedIn] = useState(false)
-  const [role, setRole] = useState('')
+  const { user, refresh } = useAuth()
   const [menuOpen, setMenuOpen] = useState(false)
-
-  useEffect(() => {
-    axios.get('/api/auth/get-session?disableRefresh=true').then(res => {
-      const user = res.data?.session?.user
-      if (user) {
-        setLoggedIn(true)
-        setRole(user.role || '')
-      }
-    })
-  }, [])
 
   const handleLogout = async () => {
     try {
       await axios.post('/api/auth/sign-out')
-    } catch (e) {
+    } catch {
       // ignore errors
     }
-    setLoggedIn(false)
+    await refresh()
     router.push('/')
   }
 
@@ -37,17 +27,17 @@ export default function AppBar() {
       <Link href="/" className="font-semibold">Game Planer</Link>
       <div className="space-x-4 flex items-center relative">
         <Link href="/" className="hover:underline">Home</Link>
-        {loggedIn ? (
+        {user ? (
           <>
             <div className="relative">
               <Button variant="ghost" onClick={() => setMenuOpen(p => !p)} className="px-2 py-1 h-auto">Menu</Button>
               {menuOpen && (
                 <div className="absolute right-0 mt-2 bg-white border rounded shadow-md z-10 min-w-[120px]">
                   <Link href="/profile" onClick={() => setMenuOpen(false)} className="block px-4 py-2 hover:bg-gray-100">Profile</Link>
-                  {role === 'super-admin' && (
+                  {user.role === 'super-admin' && (
                     <Link href="/manage" onClick={() => setMenuOpen(false)} className="block px-4 py-2 hover:bg-gray-100">Manage</Link>
                   )}
-                  {(role === 'admin' || role === 'super-admin') && (
+                  {(user.role === 'admin' || user.role === 'super-admin') && (
                     <Link href="/event-edit" onClick={() => setMenuOpen(false)} className="block px-4 py-2 hover:bg-gray-100">Event Edit</Link>
                   )}
                 </div>

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+import axios from 'axios'
+
+interface AuthUser {
+  email?: string
+  role?: string
+  name?: string
+  [key: string]: any
+}
+
+interface AuthContextValue {
+  user: AuthUser | null
+  loading: boolean
+  refresh: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const fetchSession = async () => {
+    try {
+      const res = await axios.get('/api/auth/get-session?disableRefresh=true')
+      setUser(res.data?.session?.user || null)
+    } catch {
+      setUser(null)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchSession()
+  }, [])
+
+  const refresh = async () => {
+    setLoading(true)
+    await fetchSession()
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, loading, refresh }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary
- provide `AuthProvider` and `useAuth` hook
- wrap app with provider
- replace page-specific session checks with the new hook
- refresh auth state on login/logout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684dd104b1f48322bf56bd25bbd04a68