### PR TITLE
Enable email password signup

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -11,12 +11,13 @@ async function getHandler() {
     const client = await getClient();
     const auth = betterAuth({
       adapter: mongodbAdapter(client.db()),
+      emailAndPassword: { enabled: true },
       socialProviders: {
-        google:{
+        google: {
           clientId: process.env.GOOGLE_CLIENT_ID as string,
           clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
         },
-    },
+      },
       plugins: [nextCookies()],
     });
     handler = toNextJsHandler(auth);


### PR DESCRIPTION
## Summary
- enable email & password authentication in `better-auth`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dd30bdbc083228fc18757d405f342