### PR TITLE
Implement user page with club memberships

### DIFF
--- a/app/api/myclubs/route.ts
+++ b/app/api/myclubs/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '../../../auth'
+import connect from '../../../utils/mongoose'
+import Club from '../../../models/Club'
+
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ success: false }, { status: 401 })
+  }
+  await connect()
+  const clubs = await Club.find({ 'members.id': session.user.id }, { _id: 0, name: 1 })
+  return NextResponse.json({ clubs })
+}

--- a/app/create-profile/page.tsx
+++ b/app/create-profile/page.tsx
@@ -28,7 +28,7 @@ export default function CreateProfilePage() {
     try {
       console.log({ session })
       await axios.post('/api/signup', { email, username });
-      router.push('/profile');
+      router.push('/user');
     } catch (e: any) {
       setError('Signup failed. Please try again.');
     }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -17,7 +17,7 @@ export default function LoginPage() {
     const res = await signIn("google");
     if (!res?.error) {
 
-      router.push('/profile');
+      router.push('/user');
     } else {
       setError('Login failed');
     }

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+import axios from 'axios'
+
+interface Club { name: string }
+
+export default function UserPage() {
+  const router = useRouter()
+  const { data: session, status } = useSession()
+  const [clubs, setClubs] = useState<Club[]>([])
+
+  useEffect(() => {
+    if (status === 'loading') return
+    if (!session) {
+      router.push('/login')
+      return
+    }
+    const fetchClubs = async () => {
+      const res = await axios.get('/api/myclubs')
+      setClubs(res.data.clubs)
+    }
+    fetchClubs()
+  }, [status, session, router])
+
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-2xl mb-4">My Clubs</h1>
+      {clubs.length === 0 ? (
+        <p>You are not a member of any clubs.</p>
+      ) : (
+        <ul className="list-disc list-inside">
+          {clubs.map(c => (
+            <li key={c.name}>{c.name}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/auth.ts
+++ b/auth.ts
@@ -66,8 +66,8 @@ export const authOptions: NextAuthOptions = {
       if (url.startsWith(`${baseUrl}/create-profile`)) {
         return url;
       }
-      // Otherwise, send to /profile
-      return `${baseUrl}/profile`;
+      // Otherwise, send to /user
+      return `${baseUrl}/user`;
     },
   },
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,5 +17,5 @@ export default withAuth({
 })
 
 export const config = {
-  matcher: ['/profile', '/manage', '/event-edit', '/api/profile', '/api/users/:path*', '/api/clubs/:path*', '/api/events/:path*']
+  matcher: ['/user', '/profile', '/manage', '/event-edit', '/api/profile', '/api/myclubs', '/api/users/:path*', '/api/clubs/:path*', '/api/events/:path*']
 }

--- a/models/Club.ts
+++ b/models/Club.ts
@@ -2,6 +2,12 @@ import { Schema, model, models } from 'mongoose';
 
 const clubSchema = new Schema({
   name: { type: String, required: true },
+  members: [
+    {
+      id: { type: Schema.Types.ObjectId, ref: 'User' },
+      username: String,
+    },
+  ],
 });
 
 export default models.Club || model('Club', clubSchema);


### PR DESCRIPTION
## Summary
- add club membership array in Club schema
- redirect to new `/user` page after auth
- show user clubs on `/user`
- add API endpoint for current user's clubs
- update redirects and middleware to protect new page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5a7c3ec48322881f68926f104fe8