### PR TITLE
Add club and event pages

### DIFF
--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../../../auth';
+import connect from '../../../../utils/mongoose';
+import Event from '../../../../models/Event';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  await connect();
+  const event = await Event.findById(params.id)
+    .populate('participants', 'username')
+    .lean();
+  if (!event) {
+    return NextResponse.json({ success: false }, { status: 404 });
+  }
+  const participants = (event.participants || []).map((p: any) => ({
+    id: p._id.toString(),
+    username: p.username,
+  }));
+  return NextResponse.json({
+    event: { id: event._id.toString(), name: event.name, participants },
+  });
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ success: false }, { status: 401 });
+  }
+  await connect();
+  const event = await Event.findById(params.id);
+  if (!event) {
+    return NextResponse.json({ success: false }, { status: 404 });
+  }
+  const userId = session.user.id;
+  if (!event.participants.some((p: any) => p.toString() === userId)) {
+    event.participants.push(userId);
+    await event.save();
+  }
+  return NextResponse.json({ success: true });
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session ||
+    !(session.user?.role === 'super-admin' || session.user?.role === 'admin')) {
+    return NextResponse.json({ success: false }, { status: 403 });
+  }
+  const { name } = await request.json();
+  await connect();
+  await Event.updateOne({ _id: params.id }, { name });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -6,8 +6,14 @@ import Event from '../../../models/Event';
 
 export async function GET() {
   await connect();
-  const events = await Event.find({}, { _id: 0, name: 1 });
-  return NextResponse.json({ events });
+  const events = await Event.find({}, { name: 1, club: 1 });
+  return NextResponse.json({
+    events: events.map(e => ({
+      id: e._id.toString(),
+      name: e.name,
+      club: e.club?.toString() || null,
+    })),
+  });
 }
 
 export async function POST(request: Request) {
@@ -15,8 +21,8 @@ export async function POST(request: Request) {
   if (!session || session.user?.role !== 'super-admin') {
     return NextResponse.json({ success: false }, { status: 403 });
   }
-  const { name } = await request.json();
+  const { name, clubId } = await request.json();
   await connect();
-  await Event.create({ name });
+  await Event.create({ name, club: clubId });
   return NextResponse.json({ success: true });
 }

--- a/app/api/myclubs/route.ts
+++ b/app/api/myclubs/route.ts
@@ -10,6 +10,8 @@ export async function GET() {
     return NextResponse.json({ success: false }, { status: 401 })
   }
   await connect()
-  const clubs = await Club.find({ 'members.id': session.user.id }, { _id: 0, name: 1 })
-  return NextResponse.json({ clubs })
+  const clubs = await Club.find({ 'members.id': session.user.id }, { name: 1 })
+  return NextResponse.json({
+    clubs: clubs.map(c => ({ id: c._id.toString(), name: c.name }))
+  })
 }

--- a/app/clubs/[id]/page.tsx
+++ b/app/clubs/[id]/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
+
+interface Member {
+  id: string;
+  username: string;
+}
+
+interface EventItem {
+  id: string;
+  name: string;
+}
+
+export default function ClubHome({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const { data: session, status } = useSession();
+  const [members, setMembers] = useState<Member[]>([]);
+  const [events, setEvents] = useState<EventItem[]>([]);
+  const [clubName, setClubName] = useState('');
+
+  useEffect(() => {
+    if (status === 'loading') return;
+    if (!session) {
+      router.push('/login');
+      return;
+    }
+    const fetchClub = async () => {
+      const res = await axios.get(`/api/clubs/${params.id}`);
+      setMembers(res.data.members);
+      setEvents(res.data.events);
+      setClubName(res.data.club.name);
+    };
+    fetchClub();
+  }, [status, session, router, params.id]);
+
+  const showEvents =
+    session?.user?.role === 'admin' || session?.user?.role === 'super-admin';
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">{clubName}</h1>
+      {showEvents && (
+        <div>
+          <h2 className="text-xl mb-2">Ongoing Events</h2>
+          {events.length === 0 ? (
+            <p>No events.</p>
+          ) : (
+            <ul className="list-disc list-inside space-y-1">
+              {events.map(e => (
+                <li key={e.id}>
+                  <Link href={`/events/${e.id}`} className="text-blue-600 hover:underline">
+                    {e.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+      <div>
+        <h2 className="text-xl mb-2">Members</h2>
+        <ul className="list-disc list-inside space-y-1">
+          {members.map(m => (
+            <li key={m.id}>{m.username}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
+import { Input } from '../../../components/ui/input';
+import { Button } from '../../../components/ui/button';
+
+interface Participant {
+  id: string;
+  username: string;
+}
+
+export default function EventPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const { data: session, status } = useSession();
+  const [name, setName] = useState('');
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [editingName, setEditingName] = useState('');
+
+  const fetchEvent = async () => {
+    const res = await axios.get(`/api/events/${params.id}`);
+    setName(res.data.event.name);
+    setEditingName(res.data.event.name);
+    setParticipants(res.data.event.participants);
+  };
+
+  useEffect(() => {
+    if (status === 'loading') return;
+    if (!session) {
+      router.push('/login');
+      return;
+    }
+    fetchEvent();
+  }, [status, session, router]);
+
+  const isAdmin =
+    session?.user?.role === 'admin' || session?.user?.role === 'super-admin';
+
+  const joinEvent = async () => {
+    await axios.post(`/api/events/${params.id}`);
+    fetchEvent();
+  };
+
+  const saveName = async () => {
+    await axios.put(`/api/events/${params.id}`, { name: editingName });
+    setName(editingName);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Event</h1>
+      {isAdmin ? (
+        <div className="space-x-2">
+          <Input value={editingName} onChange={e => setEditingName(e.target.value)} />
+          <Button onClick={saveName}>Save</Button>
+        </div>
+      ) : (
+        <p className="text-xl">{name}</p>
+      )}
+      <div>
+        <h2 className="text-lg mb-2">Participants</h2>
+        <ul className="list-disc list-inside space-y-1">
+          {participants.map(p => (
+            <li key={p.id}>{p.username}</li>
+          ))}
+        </ul>
+      </div>
+      {!isAdmin && (
+        <Button onClick={joinEvent}>Join Event</Button>
+      )}
+    </div>
+  );
+}

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -18,12 +18,19 @@ interface User {
   role: string;
 }
 
+interface ClubOption {
+  id: string;
+  name: string;
+}
+
 export default function ManagePage() {
   const router = useRouter();
   const { data: session, status } = useSession();
   const [users, setUsers] = useState<User[]>([]);
   const [clubName, setClubName] = useState('');
   const [eventName, setEventName] = useState('');
+  const [clubs, setClubs] = useState<ClubOption[]>([]);
+  const [selectedClub, setSelectedClub] = useState<string>('');
 
   const fetchUsers = async () => {
     const res = await axios.get('/api/users');
@@ -40,8 +47,14 @@ export default function ManagePage() {
     setClubName('');
   };
 
+  const fetchClubs = async () => {
+    const res = await axios.get('/api/clubs');
+    setClubs(res.data.clubs.map((c: any) => ({ id: c._id || c.id, name: c.name })));
+  };
+
   const handleCreateEvent = async () => {
-    await axios.post('/api/events', { name: eventName });
+    if (!selectedClub) return;
+    await axios.post('/api/events', { name: eventName, clubId: selectedClub });
     setEventName('');
   };
 
@@ -56,6 +69,7 @@ export default function ManagePage() {
       return;
     }
     fetchUsers();
+    fetchClubs();
   }, [status, session, router]);
 
   return (
@@ -99,7 +113,21 @@ export default function ManagePage() {
           <Button onClick={handleCreateClub}>Create Club</Button>
         </div>
         <div className="flex items-center space-x-2">
-          <Input placeholder="New Event Name" value={eventName} onChange={e => setEventName(e.target.value)} />
+          <Input
+            placeholder="New Event Name"
+            value={eventName}
+            onChange={e => setEventName(e.target.value)}
+          />
+          <Select value={selectedClub} onValueChange={setSelectedClub}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Select Club" />
+            </SelectTrigger>
+            <SelectContent>
+              {clubs.map(c => (
+                <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Button onClick={handleCreateEvent}>Create Event</Button>
         </div>
       </div>

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import axios from 'axios'
 
-interface Club { name: string }
+interface Club { id: string; name: string }
 
 export default function UserPage() {
   const router = useRouter()
@@ -32,7 +32,11 @@ export default function UserPage() {
       ) : (
         <ul className="list-disc list-inside">
           {clubs.map(c => (
-            <li key={c.name}>{c.name}</li>
+            <li key={c.id}>
+              <a href={`/clubs/${c.id}`} className="text-blue-600 hover:underline">
+                {c.name}
+              </a>
+            </li>
           ))}
         </ul>
       )}

--- a/models/Event.ts
+++ b/models/Event.ts
@@ -2,6 +2,8 @@ import { Schema, model, models } from 'mongoose';
 
 const eventSchema = new Schema({
   name: { type: String, required: true },
+  club: { type: Schema.Types.ObjectId, ref: 'Club' },
+  participants: [{ type: Schema.Types.ObjectId, ref: 'User' }],
 });
 
 export default models.Event || model('Event', eventSchema);


### PR DESCRIPTION
## Summary
- extend `Event` model with club and participant details
- enable club details via new API route
- enable event management via API route for join and modify actions
- allow creating events for specific clubs
- show clickable club list on user page
- display events and members on club home
- allow members to join events and admins to rename them

## Testing
- `npx next lint` *(fails: requires installing `next`)*

------
https://chatgpt.com/codex/tasks/task_e_684e5e5974a8832297c09e03aaba1ddc