### PR TITLE
Enable club join and event creation features

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -18,7 +18,12 @@ export async function GET() {
 
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
-  if (!session || session.user?.role !== 'super-admin') {
+  if (
+    !session ||
+    !(
+      session.user?.role === 'super-admin' || session.user?.role === 'admin'
+    )
+  ) {
     return NextResponse.json({ success: false }, { status: 403 });
   }
   const { name, clubId } = await request.json();

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -45,6 +45,7 @@ export default function ManagePage() {
   const handleCreateClub = async () => {
     await axios.post('/api/clubs', { name: clubName });
     setClubName('');
+    fetchClubs();
   };
 
   const fetchClubs = async () => {
@@ -129,6 +130,18 @@ export default function ManagePage() {
             </SelectContent>
           </Select>
           <Button onClick={handleCreateEvent}>Create Event</Button>
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold mt-4">All Clubs</h2>
+          <ul className="list-disc list-inside space-y-1">
+            {clubs.map(c => (
+              <li key={c.id}>
+                <a href={`/clubs/${c.id}`} className="text-blue-600 hover:underline">
+                  {c.name}
+                </a>
+              </li>
+            ))}
+          </ul>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- automatically add super admins to new clubs
- allow users to join a club via POST `/api/clubs/[id]`
- permit admins to create events
- display all clubs in manage page
- add join/create buttons on club page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e698129188322bfda306fd734b5ac