### PR TITLE
Suppress hydration warning due to Grammarly

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,11 +17,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
-      <body>
+      <body suppressHydrationWarning>
         <Providers>
           {children}
         </Providers>


### PR DESCRIPTION
## Summary
- suppress hydration warning attributes on html/body

## Testing
- `npm install`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e6b78282883229a75864c172235f6