### PR TITLE
Fix super-admin check for clubs API

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,12 @@ export default withAuth({
     authorized: ({ req, token }) => {
       if (!token) return false
       const path = req.nextUrl.pathname
-      if (path.startsWith('/manage') || path.startsWith('/api/users') || path.startsWith('/api/clubs') || path.startsWith('/api/events')) {
+      if (
+        path.startsWith('/manage') ||
+        path.startsWith('/api/users') ||
+        path === '/api/clubs' ||
+        path.startsWith('/api/events')
+      ) {
         return token.role === 'super-admin'
       }
       if (path.startsWith('/event-edit')) {


### PR DESCRIPTION
## Summary
- restrict the middleware super-admin requirement to the `/api/clubs` root path only

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6da02f18832285a6f983aa656748