### PR TITLE
Add event status and visibility

### DIFF
--- a/app/api/clubs/[id]/route.ts
+++ b/app/api/clubs/[id]/route.ts
@@ -22,11 +22,24 @@ export async function GET(
   const memberIds = club.members.map((m: any) => m.id);
   const members = await User.find({ _id: { $in: memberIds } }, { username: 1 })
     .lean();
-  const events = await Event.find({ club: params.id }, { name: 1 }).lean();
+  const events = await Event.find({ club: params.id }, {
+    name: 1,
+    status: 1,
+    visibility: 1,
+    createdAt: 1,
+    participants: 1,
+  }).lean();
   return NextResponse.json({
     club: { id: club._id.toString(), name: club.name },
     members: members.map(m => ({ id: m._id.toString(), username: m.username })),
-    events: events.map(e => ({ id: e._id.toString(), name: e.name })),
+    events: events.map(e => ({
+      id: e._id.toString(),
+      name: e.name,
+      status: e.status,
+      visibility: e.visibility,
+      createdAt: e.createdAt,
+      participantCount: e.participants.length,
+    })),
   });
 }
 

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -20,7 +20,14 @@ export async function GET(
     username: p.username,
   }));
   return NextResponse.json({
-    event: { id: event._id.toString(), name: event.name, participants },
+    event: {
+      id: event._id.toString(),
+      name: event.name,
+      status: event.status,
+      visibility: event.visibility,
+      createdAt: event.createdAt,
+      participants,
+    },
   });
 }
 
@@ -54,8 +61,12 @@ export async function PUT(
     !(session.user?.role === 'super-admin' || session.user?.role === 'admin')) {
     return NextResponse.json({ success: false }, { status: 403 });
   }
-  const { name } = await request.json();
+  const { name, status, visibility } = await request.json();
   await connect();
-  await Event.updateOne({ _id: params.id }, { name });
+  const update: any = {};
+  if (name !== undefined) update.name = name;
+  if (status !== undefined) update.status = status;
+  if (visibility !== undefined) update.visibility = visibility;
+  await Event.updateOne({ _id: params.id }, update);
   return NextResponse.json({ success: true });
 }

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -6,12 +6,23 @@ import Event from '../../../models/Event';
 
 export async function GET() {
   await connect();
-  const events = await Event.find({}, { name: 1, club: 1 });
+  const events = await Event.find({}, {
+    name: 1,
+    club: 1,
+    status: 1,
+    visibility: 1,
+    createdAt: 1,
+    participants: 1,
+  });
   return NextResponse.json({
     events: events.map(e => ({
       id: e._id.toString(),
       name: e.name,
       club: e.club?.toString() || null,
+      status: e.status,
+      visibility: e.visibility,
+      createdAt: e.createdAt,
+      participantCount: e.participants.length,
     })),
   });
 }
@@ -26,8 +37,8 @@ export async function POST(request: Request) {
   ) {
     return NextResponse.json({ success: false }, { status: 403 });
   }
-  const { name, clubId } = await request.json();
+  const { name, clubId, status, visibility } = await request.json();
   await connect();
-  await Event.create({ name, club: clubId });
+  await Event.create({ name, club: clubId, status, visibility });
   return NextResponse.json({ success: true });
 }

--- a/app/clubs/[id]/page.tsx
+++ b/app/clubs/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import axios from 'axios';
 import { Input } from '../../../components/ui/input';
 import { Button } from '../../../components/ui/button';
+import EventCard from '../../../components/EventCard';
 
 interface Member {
   id: string;
@@ -15,6 +16,10 @@ interface Member {
 interface EventItem {
   id: string;
   name: string;
+  status: string;
+  createdAt: string;
+  participantCount?: number;
+  visibility: string;
 }
 
 export default function ClubHome({ params }: { params: { id: string } }) {
@@ -46,7 +51,7 @@ export default function ClubHome({ params }: { params: { id: string } }) {
 
   const isAdmin =
     session?.user?.role === 'admin' || session?.user?.role === 'super-admin';
-  const showEvents = isAdmin;
+  const showEvents = isAdmin || isMember;
 
   const joinClub = async () => {
     await axios.post(`/api/clubs/${params.id}`);
@@ -70,18 +75,18 @@ export default function ClubHome({ params }: { params: { id: string } }) {
       {showEvents && (
         <div>
           <h2 className="text-xl mb-2">Ongoing Events</h2>
-          {events.length === 0 ? (
+          {events.filter(e => isMember || e.visibility !== 'private').length === 0 ? (
             <p>No events.</p>
           ) : (
-            <ul className="list-disc list-inside space-y-1">
-              {events.map(e => (
-                <li key={e.id}>
-                  <Link href={`/events/${e.id}`} className="text-blue-600 hover:underline">
-                    {e.name}
+            <div className="space-y-2">
+              {events
+                .filter(e => isMember || e.visibility !== 'private')
+                .map(e => (
+                  <Link key={e.id} href={`/events/${e.id}`}> 
+                    <EventCard event={e} />
                   </Link>
-                </li>
-              ))}
-            </ul>
+                ))}
+            </div>
           )}
           {isAdmin && (
             <div className="mt-2 space-x-2 flex items-center">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { Input } from '../../../components/ui/input';
 import { Button } from '../../../components/ui/button';
 import EventEdit from '../../../components/EventEdit';
+import dayjs from 'dayjs';
 
 interface Participant {
   id: string;
@@ -18,11 +19,15 @@ export default function EventPage({ params }: { params: { id: string } }) {
   const [name, setName] = useState('');
   const [participants, setParticipants] = useState<Participant[]>([]);
   const [editingName, setEditingName] = useState('');
+  const [statusText, setStatusText] = useState('');
+  const [createdAt, setCreatedAt] = useState('');
 
   const fetchEvent = async () => {
     const res = await axios.get(`/api/events/${params.id}`);
     setName(res.data.event.name);
     setEditingName(res.data.event.name);
+    setStatusText(res.data.event.status);
+    setCreatedAt(res.data.event.createdAt);
     setParticipants(res.data.event.participants);
   };
 
@@ -59,6 +64,10 @@ export default function EventPage({ params }: { params: { id: string } }) {
       ) : (
         <p className="text-xl">{name}</p>
       )}
+      <p className="text-sm text-muted-foreground">Status: {statusText}</p>
+      <p className="text-sm text-muted-foreground">
+        Created: {dayjs(createdAt).format('YYYY-MM-DD HH:mm')}
+      </p>
       <div>
         <h2 className="text-lg mb-2">Participants</h2>
         <ul className="list-disc list-inside space-y-1">

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,0 +1,27 @@
+'use client'
+import dayjs from 'dayjs'
+
+export interface EventCardProps {
+  event: {
+    id: string
+    name: string
+    status: string
+    createdAt: string
+    participantCount?: number
+  }
+}
+
+export default function EventCard({ event }: EventCardProps) {
+  return (
+    <div className="border rounded-md p-4 space-y-1">
+      <h3 className="text-lg font-semibold">{event.name}</h3>
+      <p className="text-sm text-muted-foreground">Status: {event.status}</p>
+      <p className="text-sm text-muted-foreground">
+        Created: {dayjs(event.createdAt).format('YYYY-MM-DD HH:mm')}
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Members: {event.participantCount ?? 0}
+      </p>
+    </div>
+  )
+}

--- a/models/Event.ts
+++ b/models/Event.ts
@@ -1,9 +1,22 @@
 import { Schema, model, models } from 'mongoose';
 
-const eventSchema = new Schema({
-  name: { type: String, required: true },
-  club: { type: Schema.Types.ObjectId, ref: 'Club' },
-  participants: [{ type: Schema.Types.ObjectId, ref: 'User' }],
-});
+const eventSchema = new Schema(
+  {
+    name: { type: String, required: true },
+    club: { type: Schema.Types.ObjectId, ref: 'Club' },
+    participants: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+    status: {
+      type: String,
+      enum: ['preparing', 'on-going', 'ended'],
+      default: 'preparing',
+    },
+    visibility: {
+      type: String,
+      enum: ['private', 'public-view', 'public-join'],
+      default: 'private',
+    },
+  },
+  { timestamps: true },
+);
 
 export default models.Event || model('Event', eventSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.7.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dayjs": "^1.11.13",
         "lucide-react": "^0.386.0",
         "mongodb": "^6.17.0",
         "mongoose": "^8.0.0",
@@ -1961,6 +1962,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.5",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.7.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dayjs": "^1.11.13",
     "lucide-react": "^0.386.0",
     "mongodb": "^6.17.0",
     "mongoose": "^8.0.0",


### PR DESCRIPTION
## Summary
- extend Event model with status and visibility enums
- expose new fields in events and clubs API routes
- support updating status/visibility in event API
- add `EventCard` component showing name, status, created time and member count
- display events using `EventCard` on club page
- show status and created time on event page
- install `dayjs` for datetime formatting

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f12280cc08322a6302d0becde3db2