### PR TITLE
Add detailed Club model and card

### DIFF
--- a/app/api/clubs/[id]/route.ts
+++ b/app/api/clubs/[id]/route.ts
@@ -30,7 +30,15 @@ export async function GET(
     participants: 1,
   }).lean();
   return NextResponse.json({
-    club: { id: club._id.toString(), name: club.name },
+    club: {
+      id: club._id.toString(),
+      name: club.name,
+      description: club.description,
+      location: club.location,
+      logoUrl: club.logoUrl,
+      createdBy: club.createdBy,
+      createdAt: club.createdAt,
+    },
     members: members.map(m => ({ id: m._id.toString(), username: m.username })),
     events: events.map(e => ({
       id: e._id.toString(),

--- a/app/api/clubs/route.ts
+++ b/app/api/clubs/route.ts
@@ -7,7 +7,14 @@ import User from '../../../models/User';
 
 export async function GET() {
   await connect();
-  const clubs = await Club.find({}, { _id: 0, name: 1 });
+  const clubs = await Club.find({}, {
+    name: 1,
+    description: 1,
+    location: 1,
+    logoUrl: 1,
+    createdBy: 1,
+    createdAt: 1,
+  });
   return NextResponse.json({ clubs });
 }
 
@@ -16,12 +23,17 @@ export async function POST(request: Request) {
   if (!session || session.user?.role !== 'super-admin') {
     return NextResponse.json({ success: false }, { status: 403 });
   }
-  const { name } = await request.json();
+  const { name, description, location, logoUrl } = await request.json();
   await connect();
   const user = await User.findById(session.user.id);
   const username = user?.username || user?.email || 'unknown';
   const club = await Club.create({
     name,
+    description,
+    location,
+    logoUrl,
+    createdBy: user?.email || '',
+    createdAt: new Date(),
     members: [{ id: user._id, username }],
   });
   // also store the club reference on user for convenience

--- a/app/api/myclubs/route.ts
+++ b/app/api/myclubs/route.ts
@@ -10,8 +10,26 @@ export async function GET() {
     return NextResponse.json({ success: false }, { status: 401 })
   }
   await connect()
-  const clubs = await Club.find({ 'members.id': session.user.id }, { name: 1 })
+  const clubs = await Club.find(
+    { 'members.id': session.user.id },
+    {
+      name: 1,
+      description: 1,
+      location: 1,
+      logoUrl: 1,
+      createdBy: 1,
+      createdAt: 1,
+    }
+  )
   return NextResponse.json({
-    clubs: clubs.map(c => ({ id: c._id.toString(), name: c.name }))
+    clubs: clubs.map(c => ({
+      id: c._id.toString(),
+      name: c.name,
+      description: c.description,
+      location: c.location,
+      logoUrl: c.logoUrl,
+      createdBy: c.createdBy,
+      createdAt: c.createdAt,
+    }))
   })
 }

--- a/app/clubs/[id]/page.tsx
+++ b/app/clubs/[id]/page.tsx
@@ -7,6 +7,7 @@ import axios from 'axios';
 import { Input } from '../../../components/ui/input';
 import { Button } from '../../../components/ui/button';
 import EventCard from '../../../components/EventCard';
+import ClubCard from '../../../components/ClubCard';
 
 interface Member {
   id: string;
@@ -28,6 +29,11 @@ export default function ClubHome({ params }: { params: { id: string } }) {
   const [members, setMembers] = useState<Member[]>([]);
   const [events, setEvents] = useState<EventItem[]>([]);
   const [clubName, setClubName] = useState('');
+  const [clubDesc, setClubDesc] = useState('');
+  const [clubLocation, setClubLocation] = useState('');
+  const [clubCreatedBy, setClubCreatedBy] = useState('');
+  const [clubCreatedAt, setClubCreatedAt] = useState('');
+  const [clubLogo, setClubLogo] = useState('');
   const [isMember, setIsMember] = useState(false);
   const [newEventName, setNewEventName] = useState('');
 
@@ -42,6 +48,11 @@ export default function ClubHome({ params }: { params: { id: string } }) {
       setMembers(res.data.members);
       setEvents(res.data.events);
       setClubName(res.data.club.name);
+      setClubDesc(res.data.club.description || '');
+      setClubLocation(res.data.club.location || '');
+      setClubCreatedBy(res.data.club.createdBy || '');
+      setClubCreatedAt(res.data.club.createdAt || '');
+      setClubLogo(res.data.club.logoUrl || '');
       setIsMember(
         res.data.members.some((m: Member) => m.id === session?.user?.id)
       );
@@ -58,6 +69,12 @@ export default function ClubHome({ params }: { params: { id: string } }) {
     const res = await axios.get(`/api/clubs/${params.id}`);
     setMembers(res.data.members);
     setEvents(res.data.events);
+    setClubName(res.data.club.name);
+    setClubDesc(res.data.club.description || '');
+    setClubLocation(res.data.club.location || '');
+    setClubCreatedBy(res.data.club.createdBy || '');
+    setClubCreatedAt(res.data.club.createdAt || '');
+    setClubLogo(res.data.club.logoUrl || '');
     setIsMember(res.data.members.some((m: Member) => m.id === session?.user?.id));
   };
 
@@ -67,11 +84,27 @@ export default function ClubHome({ params }: { params: { id: string } }) {
     setNewEventName('');
     const res = await axios.get(`/api/clubs/${params.id}`);
     setEvents(res.data.events);
+    setClubName(res.data.club.name);
+    setClubDesc(res.data.club.description || '');
+    setClubLocation(res.data.club.location || '');
+    setClubCreatedBy(res.data.club.createdBy || '');
+    setClubCreatedAt(res.data.club.createdAt || '');
+    setClubLogo(res.data.club.logoUrl || '');
   };
 
   return (
     <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-semibold">{clubName}</h1>
+      <ClubCard
+        club={{
+          id: params.id,
+          name: clubName,
+          description: clubDesc,
+          location: clubLocation,
+          createdBy: clubCreatedBy,
+          createdAt: clubCreatedAt,
+          logoUrl: clubLogo,
+        }}
+      />
       {showEvents && (
         <div>
           <h2 className="text-xl mb-2">Ongoing Events</h2>

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -12,6 +12,8 @@ import {
 } from '../../components/ui/select';
 import { Input } from '../../components/ui/input';
 import { Button } from '../../components/ui/button';
+import ClubCard from '../../components/ClubCard';
+import Link from 'next/link';
 
 interface User {
   username: string;
@@ -21,6 +23,11 @@ interface User {
 interface ClubOption {
   id: string;
   name: string;
+  description?: string;
+  location?: string;
+  createdBy?: string;
+  createdAt?: string;
+  logoUrl?: string;
 }
 
 export default function ManagePage() {
@@ -50,7 +57,17 @@ export default function ManagePage() {
 
   const fetchClubs = async () => {
     const res = await axios.get('/api/clubs');
-    setClubs(res.data.clubs.map((c: any) => ({ id: c._id || c.id, name: c.name })));
+    setClubs(
+      res.data.clubs.map((c: any) => ({
+        id: c._id || c.id,
+        name: c.name,
+        description: c.description,
+        location: c.location,
+        logoUrl: c.logoUrl,
+        createdBy: c.createdBy,
+        createdAt: c.createdAt,
+      }))
+    );
   };
 
   const handleCreateEvent = async () => {
@@ -133,15 +150,13 @@ export default function ManagePage() {
         </div>
         <div>
           <h2 className="text-lg font-semibold mt-4">All Clubs</h2>
-          <ul className="list-disc list-inside space-y-1">
-            {clubs.map((c, idx) => (
-              <li key={idx}>
-                <a href={`/clubs/${c.id}`} className="text-blue-600 hover:underline">
-                  {c.name}
-                </a>
-              </li>
+          <div className="space-y-2">
+            {clubs.map(c => (
+              <Link key={c.id} href={`/clubs/${c.id}`}> 
+                <ClubCard club={c} />
+              </Link>
             ))}
-          </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -3,8 +3,18 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import axios from 'axios'
+import Link from 'next/link'
+import ClubCard from '../../components/ClubCard'
 
-interface Club { id: string; name: string }
+interface Club {
+  id: string
+  name: string
+  description?: string
+  location?: string
+  createdBy?: string
+  createdAt?: string
+  logoUrl?: string
+}
 
 export default function UserPage() {
   const router = useRouter()
@@ -30,15 +40,13 @@ export default function UserPage() {
       {clubs.length === 0 ? (
         <p>You are not a member of any clubs.</p>
       ) : (
-        <ul className="list-disc list-inside">
+        <div className="space-y-2">
           {clubs.map(c => (
-            <li key={c.id}>
-              <a href={`/clubs/${c.id}`} className="text-blue-600 hover:underline">
-                {c.name}
-              </a>
-            </li>
+            <Link key={c.id} href={`/clubs/${c.id}`}>
+              <ClubCard club={c} />
+            </Link>
           ))}
-        </ul>
+        </div>
       )}
     </div>
   )

--- a/components/ClubCard.tsx
+++ b/components/ClubCard.tsx
@@ -1,0 +1,45 @@
+'use client'
+import dayjs from 'dayjs'
+
+export interface ClubCardProps {
+  club: {
+    id: string
+    name: string
+    description?: string
+    location?: string
+    createdBy?: string
+    createdAt?: string
+    logoUrl?: string
+  }
+}
+
+export default function ClubCard({ club }: ClubCardProps) {
+  return (
+    <div className="border rounded-md p-4 flex space-x-4 items-start">
+      {club.logoUrl && (
+        <img
+          src={club.logoUrl}
+          alt={club.name}
+          className="w-12 h-12 object-cover rounded-full"
+        />
+      )}
+      <div className="space-y-1">
+        <h3 className="text-lg font-semibold">{club.name}</h3>
+        {club.description && (
+          <p className="text-sm text-muted-foreground">{club.description}</p>
+        )}
+        {club.location && (
+          <p className="text-sm text-muted-foreground">Location: {club.location}</p>
+        )}
+        {club.createdBy && (
+          <p className="text-sm text-muted-foreground">Created by: {club.createdBy}</p>
+        )}
+        {club.createdAt && (
+          <p className="text-sm text-muted-foreground">
+            Created: {dayjs(club.createdAt).format('YYYY-MM-DD HH:mm')}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/models/Club.ts
+++ b/models/Club.ts
@@ -2,6 +2,11 @@ import { Schema, model, models } from 'mongoose';
 
 const clubSchema = new Schema({
   name: { type: String, required: true },
+  description: String,
+  location: String,
+  createdBy: String,
+  createdAt: { type: Date, default: Date.now },
+  logoUrl: String,
   members: [
     {
       id: { type: Schema.Types.ObjectId, ref: 'User' },


### PR DESCRIPTION
## Summary
- extend `Club` model with description, location, createdBy, createdAt and logoUrl
- expose new fields in club related API routes
- display clubs with new `ClubCard` component
- show club information on user, manage and club pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f2a5ef8fc8322b2d20946a132e729