### PR TITLE
Fix build by loosening types in API routes

### DIFF
--- a/app/api/clubs/[id]/route.ts
+++ b/app/api/clubs/[id]/route.ts
@@ -15,14 +15,14 @@ export async function GET(
     return NextResponse.json({ success: false }, { status: 401 });
   }
   await connect();
-  const club = await Club.findById(params.id).lean();
+  const club: any = await Club.findById(params.id).lean();
   if (!club) {
     return NextResponse.json({ success: false }, { status: 404 });
   }
   const memberIds = club.members.map((m: any) => m.id);
-  const members = await User.find({ _id: { $in: memberIds } }, { username: 1 })
+  const members: any[] = await User.find({ _id: { $in: memberIds } }, { username: 1 })
     .lean();
-  const events = await Event.find({ club: params.id }, {
+  const events: any[] = await Event.find({ club: params.id }, {
     name: 1,
     status: 1,
     visibility: 1,

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -9,7 +9,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   await connect();
-  const event = await Event.findById(params.id)
+  const event: any = await Event.findById(params.id)
     .populate('participants', 'username')
     .lean();
   if (!event) {


### PR DESCRIPTION
## Summary
- silence TypeScript errors in the club and event API handlers

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f2c76895c8322b11ebf9ed287d301