### PR TITLE
Add API hook and loading skeleton

### DIFF
--- a/app/clubs/[id]/page.tsx
+++ b/app/clubs/[id]/page.tsx
@@ -61,7 +61,7 @@ export default function ClubHome({ params }: { params: { id: string } }) {
       setIsMember(res.members.some((m: Member) => m.id === session?.user?.id));
     };
     fetchClub();
-  }, [status, session, router, params.id]);
+  }, [status, session, router, params.id, request]);
 
   const isAdmin =
     session?.user?.role === 'admin' || session?.user?.role === 'super-admin';

--- a/app/create-profile/page.tsx
+++ b/app/create-profile/page.tsx
@@ -3,15 +3,17 @@
 import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import axios from 'axios';
 import Link from 'next/link';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
+import PageSkeleton from '../../components/PageSkeleton'
+import { useApi } from '../../lib/useApi'
 
 
 export default function CreateProfilePage() {
   const router = useRouter();
   const { data: session } = useSession();
+  const { request, loading, error } = useApi();
 
   const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
@@ -26,13 +28,24 @@ export default function CreateProfilePage() {
 
   const handleSubmit = async () => {
     try {
-      console.log({ session })
-      await axios.post('/api/signup', { email, username });
+      await request({
+        url: '/api/signup',
+        method: 'post',
+        data: { email, username },
+      });
       router.push('/user');
     } catch (e: any) {
       setError('Signup failed. Please try again.');
     }
   };
+
+  if (loading) {
+    return <PageSkeleton />;
+  }
+
+  if (error) {
+    return <div className="p-4">Failed to load.</div>;
+  }
 
   return (
     <div className="mx-auto max-w-xs py-8">

--- a/app/create-profile/page.tsx
+++ b/app/create-profile/page.tsx
@@ -13,7 +13,7 @@ import { useApi } from '../../lib/useApi'
 export default function CreateProfilePage() {
   const router = useRouter();
   const { data: session } = useSession();
-  const { request, loading, error } = useApi();
+  const { request, loading, error: apiError } = useApi();
 
   const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
@@ -43,7 +43,7 @@ export default function CreateProfilePage() {
     return <PageSkeleton />;
   }
 
-  if (error) {
+  if (apiError) {
     return <div className="p-4">Failed to load.</div>;
   }
 

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Input } from '../../../components/ui/input';
@@ -24,7 +24,7 @@ export default function EventPage({ params }: { params: { id: string } }) {
   const [statusText, setStatusText] = useState('');
   const [createdAt, setCreatedAt] = useState('');
 
-  const fetchEvent = async () => {
+  const fetchEvent = useCallback(async () => {
     const res = await request<{ event: any }>({
       url: `/api/events/${params.id}`,
       method: 'get',
@@ -34,7 +34,7 @@ export default function EventPage({ params }: { params: { id: string } }) {
     setStatusText(res.event.status);
     setCreatedAt(res.event.createdAt);
     setParticipants(res.event.participants);
-  };
+  }, [params.id, request]);
 
   useEffect(() => {
     if (status === 'loading') return;
@@ -43,7 +43,7 @@ export default function EventPage({ params }: { params: { id: string } }) {
       return;
     }
     fetchEvent();
-  }, [status, session, router]);
+  }, [status, session, router, fetchEvent]);
 
   const isAdmin =
     session?.user?.role === 'admin' || session?.user?.role === 'super-admin';

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -2,10 +2,11 @@
 import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import axios from 'axios';
 import { Input } from '../../../components/ui/input';
 import { Button } from '../../../components/ui/button';
 import EventEdit from '../../../components/EventEdit';
+import PageSkeleton from '../../../components/PageSkeleton'
+import { useApi } from '../../../lib/useApi'
 import dayjs from 'dayjs';
 
 interface Participant {
@@ -16,6 +17,7 @@ interface Participant {
 export default function EventPage({ params }: { params: { id: string } }) {
   const router = useRouter();
   const { data: session, status } = useSession();
+  const { request, loading, error } = useApi();
   const [name, setName] = useState('');
   const [participants, setParticipants] = useState<Participant[]>([]);
   const [editingName, setEditingName] = useState('');
@@ -23,12 +25,15 @@ export default function EventPage({ params }: { params: { id: string } }) {
   const [createdAt, setCreatedAt] = useState('');
 
   const fetchEvent = async () => {
-    const res = await axios.get(`/api/events/${params.id}`);
-    setName(res.data.event.name);
-    setEditingName(res.data.event.name);
-    setStatusText(res.data.event.status);
-    setCreatedAt(res.data.event.createdAt);
-    setParticipants(res.data.event.participants);
+    const res = await request<{ event: any }>({
+      url: `/api/events/${params.id}`,
+      method: 'get',
+    });
+    setName(res.event.name);
+    setEditingName(res.event.name);
+    setStatusText(res.event.status);
+    setCreatedAt(res.event.createdAt);
+    setParticipants(res.event.participants);
   };
 
   useEffect(() => {
@@ -44,14 +49,26 @@ export default function EventPage({ params }: { params: { id: string } }) {
     session?.user?.role === 'admin' || session?.user?.role === 'super-admin';
 
   const joinEvent = async () => {
-    await axios.post(`/api/events/${params.id}`);
+    await request({ url: `/api/events/${params.id}`, method: 'post' });
     fetchEvent();
   };
 
   const saveName = async () => {
-    await axios.put(`/api/events/${params.id}`, { name: editingName });
+    await request({
+      url: `/api/events/${params.id}`,
+      method: 'put',
+      data: { name: editingName },
+    });
     setName(editingName);
   };
+
+  if (status === 'loading' || loading) {
+    return <PageSkeleton />
+  }
+
+  if (error) {
+    return <div className="p-4">Failed to load.</div>
+  }
 
   return (
     <div className="p-4 space-y-4">

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import PageSkeleton from '../../components/PageSkeleton'
@@ -41,10 +41,10 @@ export default function ManagePage() {
   const [clubs, setClubs] = useState<ClubOption[]>([]);
   const [selectedClub, setSelectedClub] = useState<string>('');
 
-  const fetchUsers = async () => {
+  const fetchUsers = useCallback(async () => {
     const res = await request<{ users: User[] }>({ url: '/api/users', method: 'get' });
     setUsers(res.users);
-  };
+  }, [request]);
 
   const handleRoleChange = async (username: string, newRole: string) => {
     await request({
@@ -61,7 +61,7 @@ export default function ManagePage() {
     fetchClubs();
   };
 
-  const fetchClubs = async () => {
+  const fetchClubs = useCallback(async () => {
     const res = await request<{ clubs: any[] }>({ url: '/api/clubs', method: 'get' });
     setClubs(
       res.clubs.map((c: any) => ({
@@ -74,7 +74,7 @@ export default function ManagePage() {
         createdAt: c.createdAt,
       }))
     );
-  };
+  }, [request]);
 
   const handleCreateEvent = async () => {
     if (!selectedClub) return;
@@ -98,7 +98,7 @@ export default function ManagePage() {
     }
     fetchUsers();
     fetchClubs();
-  }, [status, session, router]);
+  }, [status, session, router, fetchUsers, fetchClubs]);
 
   if (status === 'loading' || loading) {
     return <PageSkeleton />

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -34,7 +34,7 @@ export default function UserPage() {
       setClubs(res.clubs)
     }
     fetchClubs()
-  }, [status, session, router])
+  }, [status, session, router, request])
 
   if (status === 'loading' || loading) {
     return <PageSkeleton />

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -2,9 +2,10 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
-import axios from 'axios'
 import Link from 'next/link'
 import ClubCard from '../../components/ClubCard'
+import PageSkeleton from '../../components/PageSkeleton'
+import { useApi } from '../../lib/useApi'
 
 interface Club {
   id: string
@@ -19,6 +20,7 @@ interface Club {
 export default function UserPage() {
   const router = useRouter()
   const { data: session, status } = useSession()
+  const { request, loading, error } = useApi()
   const [clubs, setClubs] = useState<Club[]>([])
 
   useEffect(() => {
@@ -28,11 +30,19 @@ export default function UserPage() {
       return
     }
     const fetchClubs = async () => {
-      const res = await axios.get('/api/myclubs')
-      setClubs(res.data.clubs)
+      const res = await request<{ clubs: Club[] }>({ url: '/api/myclubs', method: 'get' })
+      setClubs(res.clubs)
     }
     fetchClubs()
   }, [status, session, router])
+
+  if (status === 'loading' || loading) {
+    return <PageSkeleton />
+  }
+
+  if (error) {
+    return <div className="p-4">Failed to load.</div>
+  }
 
   return (
     <div className="p-4 space-y-2">

--- a/components/PageSkeleton.tsx
+++ b/components/PageSkeleton.tsx
@@ -1,0 +1,13 @@
+'use client'
+import { Skeleton } from './ui/skeleton'
+
+export default function PageSkeleton() {
+  return (
+    <div className="p-4 space-y-2">
+      <Skeleton className="h-6 w-1/3" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-2/3" />
+    </div>
+  )
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,9 @@
+import { cn } from '../../lib/utils'
+
+interface SkeletonProps {
+  className?: string
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return <div className={cn('animate-pulse bg-muted rounded-md', className)} />
+}

--- a/lib/useApi.ts
+++ b/lib/useApi.ts
@@ -1,0 +1,23 @@
+import { useState, useCallback } from 'react'
+import axios, { AxiosRequestConfig } from 'axios'
+
+export function useApi() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<any>(null)
+
+  const request = useCallback(async <T,>(config: AxiosRequestConfig) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await axios.request<T>(config)
+      return response.data
+    } catch (err) {
+      setError(err)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return { request, loading, error }
+}


### PR DESCRIPTION
## Summary
- add Skeleton component and simple PageSkeleton wrapper
- introduce `useApi` hook for consistent request handling
- refactor pages to use the hook and show skeletons when loading

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f31436768832299bb134063c3b2c3