### PR TITLE
Add event registration flow

### DIFF
--- a/app/api/clubs/[id]/route.ts
+++ b/app/api/clubs/[id]/route.ts
@@ -26,6 +26,8 @@ export async function GET(
     name: 1,
     status: 1,
     visibility: 1,
+    registrationEndTime: 1,
+    location: 1,
     createdAt: 1,
     participants: 1,
   }).lean();
@@ -45,6 +47,8 @@ export async function GET(
       name: e.name,
       status: e.status,
       visibility: e.visibility,
+      registrationEndTime: e.registrationEndTime,
+      location: e.location,
       createdAt: e.createdAt,
       participantCount: e.participants.length,
     })),

--- a/app/api/clubs/[id]/route.ts
+++ b/app/api/clubs/[id]/route.ts
@@ -78,8 +78,9 @@ export async function POST(
     club.members.push({ id: user._id, username });
     await club.save();
   }
-  if (!user.club) {
-    user.club = club._id;
+  if (!Array.isArray(user.clubs)) user.clubs = [];
+  if (!user.clubs.some((c: any) => c.toString() === club._id.toString())) {
+    user.clubs.push(club._id);
     await user.save();
   }
   return NextResponse.json({ success: true });

--- a/app/api/clubs/route.ts
+++ b/app/api/clubs/route.ts
@@ -38,8 +38,11 @@ export async function POST(request: Request) {
   });
   // also store the club reference on user for convenience
   if (user) {
-    user.club = club._id;
-    await user.save();
+    if (!Array.isArray(user.clubs)) user.clubs = [];
+    if (!user.clubs.some((c: any) => c.toString() === club._id.toString())) {
+      user.clubs.push(club._id);
+      await user.save();
+    }
   }
   return NextResponse.json({ success: true });
 }

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -3,7 +3,6 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../../../../auth';
 import connect from '../../../../utils/mongoose';
 import Event from '../../../../models/Event';
-import User from '../../../../models/User';
 
 export async function GET(
   request: Request,
@@ -50,13 +49,12 @@ export async function POST(
   if (!event) {
     return NextResponse.json({ success: false }, { status: 404 });
   }
-  const user = await User.findById(session.user.id);
   const canRegister =
     event.status === 'registration' &&
     (!event.registrationEndTime || event.registrationEndTime > new Date()) &&
     (
       event.visibility === 'public-join' ||
-      (user && event.club && user.club && user.club.toString() === event.club.toString()) ||
+      (event.club && session.user.clubs && session.user.clubs.includes(event.club.toString())) ||
       session.user.role === 'admin' ||
       session.user.role === 'super-admin'
     );

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -3,7 +3,6 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../../../auth';
 import connect from '../../../utils/mongoose';
 import Event from '../../../models/Event';
-import User from '../../../models/User';
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -13,10 +12,9 @@ export async function GET() {
   if (!session) {
     query.visibility = { $ne: 'private' };
   } else if (session.user?.role !== 'super-admin') {
-    const user = await User.findById(session.user.id);
-    const clubId = user?.club;
+    const clubIds = session.user.clubs || [];
     query = {
-      $or: [{ visibility: { $ne: 'private' } }, { club: clubId }],
+      $or: [{ visibility: { $ne: 'private' } }, { club: { $in: clubIds } }],
     };
   }
 

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request) {
   await connect();
 
   const query = email ? { email } : { username };
-  const user = await User.findOne(query).populate({ path: 'club', strictPopulate: false });
+  const user = await User.findOne(query).populate({ path: 'clubs', strictPopulate: false });
 
   if (!user) {
     return NextResponse.json({ success: false }, { status: 404 });
@@ -28,6 +28,8 @@ export async function POST(request: Request) {
     username: user.username,
     role: user.role,
     image: user.image,
-    club: user.club ? (user.club as any).name : null,
+    clubs: Array.isArray(user.clubs)
+      ? (user.clubs as any[]).map(c => c.name)
+      : [],
   });
 }

--- a/app/clubs/[id]/page.tsx
+++ b/app/clubs/[id]/page.tsx
@@ -22,6 +22,9 @@ interface EventItem {
   createdAt: string;
   participantCount?: number;
   visibility: string;
+  registrationEndTime?: string;
+  location?: string;
+  clubName?: string | null;
 }
 
 export default function ClubHome({ params }: { params: { id: string } }) {
@@ -51,7 +54,7 @@ export default function ClubHome({ params }: { params: { id: string } }) {
         method: 'get',
       });
       setMembers(res.members);
-      setEvents(res.events);
+      setEvents(res.events.map(e => ({ ...e, clubName: res.club.name })));
       setClubName(res.club.name);
       setClubDesc(res.club.description || '');
       setClubLocation(res.club.location || '');
@@ -74,7 +77,7 @@ export default function ClubHome({ params }: { params: { id: string } }) {
       method: 'get',
     });
     setMembers(res.members);
-    setEvents(res.events);
+    setEvents(res.events.map(e => ({ ...e, clubName: res.club.name })));
     setClubName(res.club.name);
     setClubDesc(res.club.description || '');
     setClubLocation(res.club.location || '');
@@ -96,7 +99,7 @@ export default function ClubHome({ params }: { params: { id: string } }) {
       url: `/api/clubs/${params.id}`,
       method: 'get',
     });
-    setEvents(res.events);
+    setEvents(res.events.map(e => ({ ...e, clubName: res.club.name })));
     setClubName(res.club.name);
     setClubDesc(res.club.description || '');
     setClubLocation(res.club.location || '');

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -71,7 +71,7 @@ export default function EventPage({ params }: { params: { id: string } }) {
       visibility === 'public-join' ||
       session?.user?.role === 'super-admin' ||
       session?.user?.role === 'admin' ||
-      (session?.user?.club && session.user.club === clubId)
+      (session?.user?.clubs && session.user.clubs.includes(clubId))
     );
 
   const joinEvent = async () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,73 @@
 'use client'
 import Link from 'next/link'
+import { useSession } from 'next-auth/react'
+import { useEffect, useState } from 'react'
 import { Button } from '../components/ui/button'
+import EventCard from '../components/EventCard'
+import PageSkeleton from '../components/PageSkeleton'
+import { useApi } from '../lib/useApi'
+
+interface EventItem {
+  id: string
+  name: string
+  status: string
+  clubName?: string | null
+  registrationEndTime?: string
+  createdAt: string
+  participantCount?: number
+}
 
 export default function Home() {
-  return (
-    <div className="flex flex-col items-center justify-center py-10 space-y-4">
-      <h1 className="text-3xl font-bold">Welcome to Game Planer</h1>
-      <p className="text-center">Plan games for our lovely PIV Club members.</p>
-      <div className="space-x-4">
-        <Button asChild>
-          <Link href="/login">Login</Link>
-        </Button>
+  const { data: session, status } = useSession()
+  const { request, loading, error } = useApi()
+  const [events, setEvents] = useState<EventItem[]>([])
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    const fetchEvents = async () => {
+      const res = await request<{ events: EventItem[] }>({ url: '/api/events', method: 'get' })
+      setEvents(res.events)
+    }
+    fetchEvents()
+  }, [status, request])
+
+  if (status === 'loading' || loading) {
+    return <PageSkeleton />
+  }
+
+  if (!session) {
+    return (
+      <div className="flex flex-col items-center justify-center py-10 space-y-4">
+        <h1 className="text-3xl font-bold">Welcome to Game Planer</h1>
+        <p className="text-center">Plan games for our lovely PIV Club members.</p>
+        <div className="space-x-4">
+          <Button asChild>
+            <Link href="/login">Login</Link>
+          </Button>
+        </div>
       </div>
+    )
+  }
+
+  if (error) {
+    return <div className="p-4">Failed to load.</div>
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl mb-2">Available Events</h1>
+      {events.length === 0 ? (
+        <p>No events.</p>
+      ) : (
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {events.map(e => (
+            <Link key={e.id} href={`/events/${e.id}`}
+              className="block">
+              <EventCard event={e} />
+            </Link>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -10,7 +10,7 @@ interface ProfileData {
   username?: string;
   role?: string;
   image?: string | null;
-  club?: string | null;
+  clubs?: string[];
 }
 
 export default function ProfilePage() {
@@ -65,9 +65,9 @@ export default function ProfilePage() {
           <strong>Role:</strong> {data.role}
         </p>
       )}
-      {data.club && (
+      {data.clubs && data.clubs.length > 0 && (
         <p>
-          <strong>Club:</strong> {data.club}
+          <strong>Clubs:</strong> {data.clubs.join(', ')}
         </p>
       )}
     </div>

--- a/auth.ts
+++ b/auth.ts
@@ -12,7 +12,7 @@ declare module "next-auth" {
       email?: string | null;
       image?: string | null;
       role?: string | null;
-      club?: string | null;
+      clubs?: string[];
     };
   }
 }
@@ -22,7 +22,7 @@ declare module "next-auth/jwt" {
   interface JWT {
     id?: string;
     role?: string | null;
-    club?: string | null;
+    clubs?: string[];
   }
 }
 
@@ -36,22 +36,27 @@ export const authOptions: NextAuthOptions = {
   secret: process.env.AUTH_SECRET,
   callbacks: {
     async jwt({ token, user }) {
-      if (user) {
-        const dbUser = await User.findOne({ email: user.email });
-        token.id = dbUser!._id.toString();
-        token.role = dbUser?.role || null
-        token.club = dbUser?.club ? dbUser.club.toString() : null
+      await connect();
+      let dbUser = null;
+      if (user && user.email) {
+        dbUser = await User.findOne({ email: user.email });
+      } else if (token.id) {
+        dbUser = await User.findById(token.id);
       }
-      return token
+      if (dbUser) {
+        token.id = dbUser._id.toString();
+        token.role = dbUser.role || null;
+        token.clubs = dbUser.clubs ? dbUser.clubs.map((c: any) => c.toString()) : [];
+      }
+      return token;
     },
     async session({ session, token }) {
-      if (token.id && session.user) session.user.id = token.id as string
       if (session.user) {
-        session.user.id = token.id;
+        if (token.id) session.user.id = token.id as string;
         session.user.role = (token.role as string) || null;
-        session.user.club = (token.club as string) || null;
+        session.user.clubs = (token.clubs as string[]) || [];
       }
-      return session
+      return session;
     },
     async signIn({ user }) {
       await connect();
@@ -64,6 +69,7 @@ export const authOptions: NextAuthOptions = {
         await User.create({
           email: user.email,
           image: user.image,
+          clubs: [],
         });
       }
       // Redirect new users to create-profile

--- a/auth.ts
+++ b/auth.ts
@@ -12,6 +12,7 @@ declare module "next-auth" {
       email?: string | null;
       image?: string | null;
       role?: string | null;
+      club?: string | null;
     };
   }
 }
@@ -21,6 +22,7 @@ declare module "next-auth/jwt" {
   interface JWT {
     id?: string;
     role?: string | null;
+    club?: string | null;
   }
 }
 
@@ -38,6 +40,7 @@ export const authOptions: NextAuthOptions = {
         const dbUser = await User.findOne({ email: user.email });
         token.id = dbUser!._id.toString();
         token.role = dbUser?.role || null
+        token.club = dbUser?.club ? dbUser.club.toString() : null
       }
       return token
     },
@@ -46,6 +49,7 @@ export const authOptions: NextAuthOptions = {
       if (session.user) {
         session.user.id = token.id;
         session.user.role = (token.role as string) || null;
+        session.user.club = (token.club as string) || null;
       }
       return session
     },

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -6,6 +6,8 @@ export interface EventCardProps {
     id: string
     name: string
     status: string
+    clubName?: string | null
+    registrationEndTime?: string
     createdAt: string
     participantCount?: number
   }
@@ -15,7 +17,15 @@ export default function EventCard({ event }: EventCardProps) {
   return (
     <div className="border rounded-md p-4 space-y-1">
       <h3 className="text-lg font-semibold">{event.name}</h3>
+      {event.clubName && (
+        <p className="text-sm text-muted-foreground">Host: {event.clubName}</p>
+      )}
       <p className="text-sm text-muted-foreground">Status: {event.status}</p>
+      {event.registrationEndTime && (
+        <p className="text-sm text-muted-foreground">
+          Register by: {dayjs(event.registrationEndTime).format('YYYY-MM-DD HH:mm')}
+        </p>
+      )}
       <p className="text-sm text-muted-foreground">
         Created: {dayjs(event.createdAt).format('YYYY-MM-DD HH:mm')}
       </p>

--- a/models/Event.ts
+++ b/models/Event.ts
@@ -7,7 +7,7 @@ const eventSchema = new Schema(
     participants: [{ type: Schema.Types.ObjectId, ref: 'User' }],
     status: {
       type: String,
-      enum: ['preparing', 'on-going', 'ended'],
+      enum: ['preparing', 'registration', 'arranging-matches', 'match-running', 'ended'],
       default: 'preparing',
     },
     visibility: {
@@ -15,6 +15,8 @@ const eventSchema = new Schema(
       enum: ['private', 'public-view', 'public-join'],
       default: 'private',
     },
+    registrationEndTime: { type: Date, required: false },
+    location: { type: String },
   },
   { timestamps: true },
 );

--- a/models/User.ts
+++ b/models/User.ts
@@ -8,7 +8,7 @@ const userSchema = new Schema({
     enum: ['super-admin', 'admin', 'member'],
     default: 'member',
   },
-  club: { type: Schema.Types.ObjectId, ref: 'Club' },
+  clubs: [{ type: Schema.Types.ObjectId, ref: 'Club' }],
   image: { type: String },
 });
 


### PR DESCRIPTION
## Summary
- support additional event statuses and info
- expose registration fields from API
- filter events by user role and club
- show event list on home page when signed in
- display event details and registration button

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f3e23ef5083229dd3e02bfe6f51c6