### PR TITLE
Add reusable UserCard component

### DIFF
--- a/app/api/clubs/[id]/route.ts
+++ b/app/api/clubs/[id]/route.ts
@@ -20,8 +20,10 @@ export async function GET(
     return NextResponse.json({ success: false }, { status: 404 });
   }
   const memberIds = club.members.map((m: any) => m.id);
-  const members: any[] = await User.find({ _id: { $in: memberIds } }, { username: 1 })
-    .lean();
+  const members: any[] = await User.find(
+    { _id: { $in: memberIds } },
+    { username: 1, image: 1 }
+  ).lean();
   const events: any[] = await Event.find({ club: params.id }, {
     name: 1,
     status: 1,
@@ -41,7 +43,11 @@ export async function GET(
       createdBy: club.createdBy,
       createdAt: club.createdAt,
     },
-    members: members.map(m => ({ id: m._id.toString(), username: m.username })),
+    members: members.map(m => ({
+      id: m._id.toString(),
+      username: m.username,
+      image: m.image || null,
+    })),
     events: events.map(e => ({
       id: e._id.toString(),
       name: e.name,

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -10,7 +10,7 @@ export async function GET(
 ) {
   await connect();
   const event: any = await Event.findById(params.id)
-    .populate('participants', 'username')
+    .populate('participants', 'username image')
     .populate('club', 'name')
     .lean();
   if (!event) {
@@ -19,6 +19,7 @@ export async function GET(
   const participants = (event.participants || []).map((p: any) => ({
     id: p._id.toString(),
     username: p.username,
+    image: p.image || null,
   }));
   return NextResponse.json({
     event: {

--- a/app/clubs/[id]/page.tsx
+++ b/app/clubs/[id]/page.tsx
@@ -7,12 +7,14 @@ import { Input } from '../../../components/ui/input';
 import { Button } from '../../../components/ui/button';
 import EventCard from '../../../components/EventCard';
 import ClubCard from '../../../components/ClubCard';
+import UserCard from '../../../components/UserCard';
 import PageSkeleton from '../../../components/PageSkeleton'
 import { useApi } from '../../../lib/useApi'
 
 interface Member {
   id: string;
   username: string;
+  image?: string | null;
 }
 
 interface EventItem {
@@ -160,11 +162,11 @@ export default function ClubHome({ params }: { params: { id: string } }) {
       )}
       <div>
         <h2 className="text-xl mb-2">Members</h2>
-        <ul className="list-disc list-inside space-y-1">
+        <div className="space-y-1">
           {members?.map(m => (
-            <li key={m.id}>{m.username}</li>
+            <UserCard key={m.id} user={m} />
           ))}
-        </ul>
+        </div>
       </div>
       {!isMember && (
         <Button onClick={joinClub}>Join us!</Button>

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -7,11 +7,13 @@ import { Button } from '../../../components/ui/button';
 import EventEdit from '../../../components/EventEdit';
 import PageSkeleton from '../../../components/PageSkeleton'
 import { useApi } from '../../../lib/useApi'
+import UserCard from '../../../components/UserCard'
 import dayjs from 'dayjs';
 
 interface Participant {
   id: string;
   username: string;
+  image?: string | null;
 }
 
 export default function EventPage({ params }: { params: { id: string } }) {
@@ -124,11 +126,11 @@ export default function EventPage({ params }: { params: { id: string } }) {
       </p>
       <div>
         <h2 className="text-lg mb-2">Participants</h2>
-        <ul className="list-disc list-inside space-y-1">
+        <div className="space-y-1">
           {participants.map(p => (
-            <li key={p.id}>{p.username}</li>
+            <UserCard key={p.id} user={p} />
           ))}
-        </ul>
+        </div>
       </div>
       {canRegister && (
         <Button onClick={joinEvent}>Register</Button>

--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -1,0 +1,29 @@
+'use client'
+import Image from 'next/image'
+
+export interface UserCardProps {
+  user: {
+    id: string
+    username: string
+    image?: string | null
+  }
+}
+
+export default function UserCard({ user }: UserCardProps) {
+  return (
+    <div className="flex items-center space-x-2 p-2 border rounded-md">
+      {user.image ? (
+        <Image
+          src={user.image}
+          alt={user.username}
+          width={32}
+          height={32}
+          className="rounded-full object-cover"
+        />
+      ) : (
+        <div className="w-8 h-8 rounded-full bg-gray-300" />
+      )}
+      <span>{user.username}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a `UserCard` UI component for displaying user avatar and name
- return `image` field from club and event APIs
- show `UserCard` for members and participants lists

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f9def3044832294643f5777d2bf6d