### PR TITLE
Implement new event fields

### DIFF
--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -29,6 +29,10 @@ export async function GET(
       visibility: event.visibility,
       registrationEndTime: event.registrationEndTime,
       location: event.location,
+      gameStyle: event.gameStyle,
+      maxPoint: event.maxPoint,
+      courtCount: event.courtCount,
+      umpires: event.umpires,
       club: event.club?._id ? event.club._id.toString() : null,
       clubName: event.club?.name || null,
       createdAt: event.createdAt,
@@ -80,7 +84,17 @@ export async function PUT(
     !(session.user?.role === 'super-admin' || session.user?.role === 'admin')) {
     return NextResponse.json({ success: false }, { status: 403 });
   }
-  const { name, status, visibility, registrationEndTime, location } = await request.json();
+  const {
+    name,
+    status,
+    visibility,
+    registrationEndTime,
+    location,
+    gameStyle,
+    maxPoint,
+    courtCount,
+    umpires,
+  } = await request.json();
   await connect();
   const update: any = {};
   if (name !== undefined) update.name = name;
@@ -88,6 +102,10 @@ export async function PUT(
   if (visibility !== undefined) update.visibility = visibility;
   if (registrationEndTime !== undefined) update.registrationEndTime = registrationEndTime;
   if (location !== undefined) update.location = location;
+  if (gameStyle !== undefined) update.gameStyle = gameStyle;
+  if (maxPoint !== undefined) update.maxPoint = maxPoint;
+  if (courtCount !== undefined) update.courtCount = courtCount;
+  if (umpires !== undefined) update.umpires = umpires;
   await Event.updateOne({ _id: params.id }, update);
   return NextResponse.json({ success: true });
 }

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -25,6 +25,9 @@ export async function GET() {
     visibility: 1,
     registrationEndTime: 1,
     location: 1,
+    gameStyle: 1,
+    maxPoint: 1,
+    courtCount: 1,
     createdAt: 1,
     participants: 1,
   }).populate('club', 'name');
@@ -39,6 +42,9 @@ export async function GET() {
       visibility: e.visibility,
       registrationEndTime: e.registrationEndTime,
       location: e.location,
+      gameStyle: e.gameStyle,
+      maxPoint: e.maxPoint,
+      courtCount: e.courtCount,
       createdAt: e.createdAt,
       participantCount: e.participants.length,
     })),
@@ -55,8 +61,30 @@ export async function POST(request: Request) {
   ) {
     return NextResponse.json({ success: false }, { status: 403 });
   }
-  const { name, clubId, status, visibility, registrationEndTime, location } = await request.json();
+  const {
+    name,
+    clubId,
+    status,
+    visibility,
+    registrationEndTime,
+    location,
+    gameStyle,
+    maxPoint,
+    courtCount,
+    umpires,
+  } = await request.json();
   await connect();
-  await Event.create({ name, club: clubId, status, visibility, registrationEndTime, location });
+  await Event.create({
+    name,
+    club: clubId,
+    status,
+    visibility,
+    registrationEndTime,
+    location,
+    gameStyle,
+    maxPoint,
+    courtCount,
+    umpires,
+  });
   return NextResponse.json({ success: true });
 }

--- a/models/Event.ts
+++ b/models/Event.ts
@@ -17,6 +17,10 @@ const eventSchema = new Schema(
     },
     registrationEndTime: { type: Date, required: false },
     location: { type: String },
+    gameStyle: { type: String },
+    maxPoint: { type: Number },
+    courtCount: { type: Number },
+    umpires: [{ type: Schema.Types.ObjectId, ref: 'User' }],
   },
   { timestamps: true },
 );


### PR DESCRIPTION
## Summary
- update `Event` schema to store game style, max point, court count and umpires
- expose new fields in events API routes

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fac5070388322b394487c7b6e6ac5