### PR TITLE
Implement event step management

### DIFF
--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -109,3 +109,27 @@ export async function PUT(
   await Event.updateOne({ _id: params.id }, update);
   return NextResponse.json({ success: true });
 }
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (
+    !session ||
+    !(session.user?.role === 'super-admin' || session.user?.role === 'admin')
+  ) {
+    return NextResponse.json({ success: false }, { status: 403 });
+  }
+  const url = new URL(request.url);
+  const participantId = url.searchParams.get('participantId');
+  if (!participantId) {
+    return NextResponse.json({ success: false }, { status: 400 });
+  }
+  await connect();
+  await Event.updateOne(
+    { _id: params.id },
+    { $pull: { participants: participantId } }
+  );
+  return NextResponse.json({ success: true });
+}

--- a/components/StepIndicator.tsx
+++ b/components/StepIndicator.tsx
@@ -1,0 +1,35 @@
+'use client'
+import React from 'react'
+
+export const EVENT_STEPS = [
+  'preparing',
+  'registration',
+  'arranging-matches',
+  'match-running',
+  'ended',
+] as const
+
+export type EventStep = typeof EVENT_STEPS[number]
+
+export interface StepIndicatorProps {
+  step: EventStep
+}
+
+export default function StepIndicator({ step }: StepIndicatorProps) {
+  const currentIndex = EVENT_STEPS.indexOf(step)
+  return (
+    <ol className="flex justify-between mb-4">
+      {EVENT_STEPS.map((s, i) => (
+        <li
+          key={s}
+          className={
+            'flex-1 text-center ' +
+            (i === currentIndex ? 'font-semibold' : 'text-muted-foreground')
+          }
+        >
+          {s.replace('-', ' ')}
+        </li>
+      ))}
+    </ol>
+  )
+}


### PR DESCRIPTION
## Summary
- add a StepIndicator component for event status display
- manage event status changes and info updates on event page
- allow admins to remove participants
- expose API route to remove event participants
- share event step types across components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684faf6718f88322baa3c7495d5c327c