### PR TITLE
Fix event access for members

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../../../auth';
 import connect from '../../../utils/mongoose';
 import Event from '../../../models/Event';
+import mongoose from 'mongoose';
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -12,7 +13,9 @@ export async function GET() {
   if (!session) {
     query.visibility = { $ne: 'private' };
   } else if (session.user?.role !== 'super-admin') {
-    const clubIds = session.user.clubs || [];
+    const clubIds = (session.user.clubs || []).map(id =>
+      new mongoose.Types.ObjectId(id)
+    );
     query = {
       $or: [{ visibility: { $ne: 'private' } }, { club: { $in: clubIds } }],
     };

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,9 +8,11 @@ export default withAuth({
       if (
         path.startsWith('/manage') ||
         path.startsWith('/api/users') ||
-        path === '/api/clubs' ||
-        path.startsWith('/api/events')
+        path === '/api/clubs'
       ) {
+        return token.role === 'super-admin'
+      }
+      if (path.startsWith('/api/events') && req.method !== 'GET') {
         return token.role === 'super-admin'
       }
       if (path.startsWith('/event-edit')) {


### PR DESCRIPTION
## Summary
- ensure member events query properly matches club IDs

## Testing
- `npm run lint` *(fails: next not found)*
- `npx next lint` *(fails: network issue)*

------
https://chatgpt.com/codex/tasks/task_e_684fb1097c88832285a8c0ea6a719276