### PR TITLE
Add credential-based signup and login

### DIFF
--- a/app/api/check-email/route.ts
+++ b/app/api/check-email/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import connect from '@/utils/mongoose';
+import User from '@/models/User';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const email = searchParams.get('email');
+  if (!email) {
+    return NextResponse.json({ exists: false });
+  }
+  await connect();
+  const exists = await User.exists({ email });
+  return NextResponse.json({ exists: !!exists });
+}

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import connect from '@/utils/mongoose';
+import User from '@/models/User';
+import bcrypt from 'bcryptjs';
+
+export async function POST(request: Request) {
+  const { email, password } = await request.json();
+  if (!email || !password) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+  }
+  await connect();
+  const existing = await User.findOne({ email });
+  if (existing) {
+    return NextResponse.json({ error: 'Email already exists' }, { status: 400 });
+  }
+  const hashed = await bcrypt.hash(password, 10);
+  await User.create({ email, password: hashed });
+  return NextResponse.json({ success: true });
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -13,16 +13,44 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
-  const handleSubmit = async () => {
-    await signIn("google");
+  const handleEmailLogin = async () => {
+    const res = await signIn('credentials', {
+      redirect: false,
+      email,
+      password,
+    });
+    if (res?.error) {
+      setError('Invalid credentials');
+    } else {
+      router.push('/user');
+    }
+  };
+
+  const handleGoogle = async () => {
+    await signIn('google');
   };
 
   return (
     <div className="mx-auto max-w-xs py-8">
       <h1 className="text-2xl font-semibold mb-4">Login</h1>
       <div className="space-y-4">
+        <Input
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
         {error && <p className="text-red-500 text-sm">{error}</p>}
-        <Button className="w-full" onClick={handleSubmit}>Login With Google</Button>
+        <Button className="w-full" onClick={handleEmailLogin}>Login</Button>
+        <Button className="w-full" onClick={handleGoogle}>Login With Google</Button>
+        <Button variant="outline" className="w-full" asChild>
+          <Link href="/signup">Sign Up</Link>
+        </Button>
       </div>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,6 +44,9 @@ export default function Home() {
           <Button asChild>
             <Link href="/login">Login</Link>
           </Button>
+          <Button variant="outline" asChild>
+            <Link href="/signup">Sign Up</Link>
+          </Button>
         </div>
       </div>
     )

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
+import { useApi } from '../../lib/useApi';
+
+export default function SignupPage() {
+  const router = useRouter();
+  const { request } = useApi();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [error, setError] = useState('');
+
+  const handleEmailBlur = async () => {
+    const valid = /\S+@\S+\.\S+/.test(email);
+    if (!valid) {
+      setEmailError('Invalid email');
+      return;
+    }
+    try {
+      const res = await request<{ exists: boolean }>({
+        url: `/api/check-email?email=${encodeURIComponent(email)}`,
+        method: 'get',
+      });
+      if (res.exists) {
+        setEmailError('Email already registered');
+      } else {
+        setEmailError('');
+      }
+    } catch {
+      setEmailError('Error checking email');
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (emailError) return;
+    try {
+      await request({
+        url: '/api/register',
+        method: 'post',
+        data: { email, password },
+      });
+      router.push('/login');
+    } catch {
+      setError('Signup failed.');
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-xs py-8">
+      <h1 className="text-2xl font-semibold mb-4">Sign Up</h1>
+      <div className="space-y-4">
+        <Input
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          onBlur={handleEmailBlur}
+        />
+        {emailError && <p className="text-red-500 text-sm">{emailError}</p>}
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <Button className="w-full" onClick={handleSubmit}>Sign Up</Button>
+        <Button variant="outline" className="w-full" asChild>
+          <Link href="/login">Back to Login</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/models/User.ts
+++ b/models/User.ts
@@ -10,6 +10,7 @@ const userSchema = new Schema({
   },
   clubs: [{ type: Schema.Types.ObjectId, ref: 'Club' }],
   image: { type: String },
+  password: { type: String },
 });
 
 export default models.User || model('User', userSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.0.2",
         "axios": "^1.7.2",
+        "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.13",
@@ -1654,6 +1655,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.0.2",
     "axios": "^1.7.2",
+    "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
## Summary
- add password field to `User` schema
- support credential login in NextAuth
- implement `/signup` page with client-side email check
- enable credential-based login alongside Google
- add signup button on home page
- provide API routes for credential registration and email lookup

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850f5e748b8832282cc1663ebc6df4c