### PR TITLE
Add default avatar and update signup flow

### DIFF
--- a/app/create-profile/page.tsx
+++ b/app/create-profile/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
@@ -13,18 +13,22 @@ import { useApi } from '../../lib/useApi'
 export default function CreateProfilePage() {
   const router = useRouter();
   const { data: session } = useSession();
+  const searchParams = useSearchParams();
   const { request, loading, error: apiError } = useApi();
 
   const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
   const [error, setError] = useState('');
 
-  // Populate email from NextAuth session
+  // Populate email from NextAuth session or query param
   useEffect(() => {
     if (session?.user?.email) {
       setEmail(session.user.email);
+    } else {
+      const param = searchParams.get('email');
+      if (param) setEmail(param);
     }
-  }, [session]);
+  }, [session, searchParams]);
 
   const handleSubmit = async () => {
     try {
@@ -33,7 +37,7 @@ export default function CreateProfilePage() {
         method: 'post',
         data: { email, username },
       });
-      router.push('/user');
+      router.push('/login');
     } catch (e: any) {
       setError('Signup failed. Please try again.');
     }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import Image from "next/image";
+import Avatar from "boring-avatars";
 import PageSkeleton from "../../components/PageSkeleton";
 import { useApi } from "../../lib/useApi";
 
@@ -42,16 +43,18 @@ export default function ProfilePage() {
   return (
     <div className="p-4 space-y-2">
       <h1 className="text-2xl mb-4">Profile</h1>
-      {data.image && (
-  <Image
-    src={data.image}
-    alt="Profile picture"
-    width={96}
-    height={96}
-    className="rounded-full"
-    priority
-  />
-)}
+      {data.image ? (
+        <Image
+          src={data.image}
+          alt="Profile picture"
+          width={96}
+          height={96}
+          className="rounded-full"
+          priority
+        />
+      ) : (
+        <Avatar size={96} name={data.username || data.email} variant="beam" />
+      )}
       <p>
         <strong>Email:</strong> {data.email}
       </p>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -43,7 +43,7 @@ export default function SignupPage() {
         method: 'post',
         data: { email, password },
       });
-      router.push('/login');
+      router.push(`/create-profile?email=${encodeURIComponent(email)}`);
     } catch {
       setError('Signup failed.');
     }

--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 import Image from 'next/image'
+import Avatar from 'boring-avatars'
 
 export interface UserCardProps {
   user: {
@@ -21,7 +22,7 @@ export default function UserCard({ user }: UserCardProps) {
           className="rounded-full object-cover"
         />
       ) : (
-        <div className="w-8 h-8 rounded-full bg-gray-300" />
+        <Avatar size={32} name={user.username} variant="beam" />
       )}
       <span>{user.username}</span>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-slot": "^1.0.2",
         "axios": "^1.7.2",
         "bcryptjs": "^3.0.2",
+        "boring-avatars": "^1.11.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.13",
@@ -1675,6 +1676,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/boring-avatars": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/boring-avatars/-/boring-avatars-1.11.2.tgz",
+      "integrity": "sha512-3+wkwPeObwS4R37FGXMYViqc4iTrIRj5yzfX9Qy4mnpZ26sX41dGMhsAgmKks1r/uufY1pl4vpgzMWHYfJRb2A==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "axios": "^1.7.2",
     "bcryptjs": "^3.0.2",
+    "boring-avatars": "^1.11.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
## Summary
- add `boring-avatars` dependency for placeholder avatars
- show `boring-avatars` for users without profile images
- after signing up navigate to `/create-profile` instead of `/login`
- after saving profile redirect to `/login`
- support passing email to `create-profile` via query params

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850fca9a10483229d70f1ed68d89f2a