### PR TITLE
Add username and password update to profile page

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -4,6 +4,8 @@ import { useSession } from "next-auth/react";
 import Image from "next/image";
 import PageSkeleton from "../../components/PageSkeleton";
 import { useApi } from "../../lib/useApi";
+import { Input } from "../../components/ui/input";
+import { Button } from "../../components/ui/button";
 
 interface ProfileData {
   email: string;
@@ -17,6 +19,9 @@ export default function ProfilePage() {
   const { data: session } = useSession();
   const { request, loading, error } = useApi();
   const [data, setData] = useState<ProfileData | null>(null);
+  const [usernameEdit, setUsernameEdit] = useState('');
+  const [passwordEdit, setPasswordEdit] = useState('');
+  const [message, setMessage] = useState('');
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -40,7 +45,7 @@ export default function ProfilePage() {
   }
 
   return (
-    <div className="p-4 space-y-2">
+    <div className="p-4 space-y-4">
       <h1 className="text-2xl mb-4">Profile</h1>
       {data.image && (
   <Image
@@ -70,6 +75,63 @@ export default function ProfilePage() {
           <strong>Clubs:</strong> {data.clubs.join(', ')}
         </p>
       )}
+      <div className="space-y-2 pt-4">
+        <h2 className="text-xl">Update Username</h2>
+        <Input
+          placeholder="New username"
+          value={usernameEdit}
+          onChange={e => setUsernameEdit(e.target.value)}
+        />
+        <Button
+          onClick={async () => {
+            setMessage('');
+            try {
+              await request({
+                url: '/api/profile',
+                method: 'put',
+                data: { username: usernameEdit },
+              });
+              setData(prev =>
+                prev ? { ...prev, username: usernameEdit } : prev
+              );
+              setUsernameEdit('');
+              setMessage('Username updated');
+            } catch {
+              setMessage('Failed to update username');
+            }
+          }}
+        >
+          Save Username
+        </Button>
+      </div>
+      <div className="space-y-2 pt-4">
+        <h2 className="text-xl">Change Password</h2>
+        <Input
+          type="password"
+          placeholder="New password"
+          value={passwordEdit}
+          onChange={e => setPasswordEdit(e.target.value)}
+        />
+        <Button
+          onClick={async () => {
+            setMessage('');
+            try {
+              await request({
+                url: '/api/profile',
+                method: 'put',
+                data: { password: passwordEdit },
+              });
+              setPasswordEdit('');
+              setMessage('Password updated');
+            } catch {
+              setMessage('Failed to update password');
+            }
+          }}
+        >
+          Save Password
+        </Button>
+      </div>
+      {message && <p className="text-green-500">{message}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow updating username and password via a new PUT handler in `/api/profile`
- add edit fields and actions on the profile page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850fd017f5c8322ad651360cb7d2d6c