### PR TITLE
Fix create profile build error

### DIFF
--- a/app/create-profile/page.tsx
+++ b/app/create-profile/page.tsx
@@ -10,7 +10,9 @@ import PageSkeleton from '../../components/PageSkeleton'
 import { useApi } from '../../lib/useApi'
 
 
-export default function CreateProfilePage() {
+import { Suspense } from 'react';
+
+function CreateProfileClient() {
   const router = useRouter();
   const { data: session } = useSession();
   const searchParams = useSearchParams();
@@ -69,5 +71,13 @@ export default function CreateProfilePage() {
         </Button>
       </div>
     </div>
+  );
+}
+
+export default function CreateProfilePage() {
+  return (
+    <Suspense>
+      <CreateProfileClient />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap create-profile page content in a Suspense boundary

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850ff0c30c48322b0686bf333179861