### PR TITLE
Allow participants to leave events

### DIFF
--- a/app/api/events/[id]/leave/route.ts
+++ b/app/api/events/[id]/leave/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../../../../auth';
+import connect from '../../../../../utils/mongoose';
+import Event from '../../../../../models/Event';
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ success: false }, { status: 401 });
+  }
+
+  await connect();
+  const event = await Event.findById(params.id);
+  if (!event) {
+    return NextResponse.json({ success: false }, { status: 404 });
+  }
+  const isParticipant = event.participants.some(
+    (p: any) => p.toString() === session.user.id
+  );
+  const canLeave =
+    event.status === 'registration' &&
+    (!event.registrationEndTime || event.registrationEndTime > new Date());
+
+  if (!isParticipant || !canLeave) {
+    return NextResponse.json({ success: false }, { status: 403 });
+  }
+
+  await Event.updateOne(
+    { _id: params.id },
+    { $pull: { participants: session.user.id } }
+  );
+  return NextResponse.json({ success: true });
+}

--- a/components/EventContent.tsx
+++ b/components/EventContent.tsx
@@ -22,6 +22,7 @@ interface EventContentProps {
   status: EventStep
   isAdmin: boolean
   participants: Participant[]
+  currentUserId?: string
   editingName: string
   setEditingName: (v: string) => void
   editingVisibility: string
@@ -45,6 +46,7 @@ export default function EventContent({
   status,
   isAdmin,
   participants,
+  currentUserId,
   editingName,
   setEditingName,
   editingVisibility,
@@ -125,9 +127,9 @@ export default function EventContent({
             {participants.map(p => (
               <div key={p.id} className="flex items-center justify-between">
                 <UserCard user={p} />
-                {isAdmin && (
+                {(isAdmin || p.id === currentUserId) && (
                   <Button variant="ghost" onClick={() => removeParticipant(p.id)}>
-                    Remove
+                    {p.id === currentUserId ? 'Leave' : 'Remove'}
                   </Button>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- add endpoint for participants to leave events
- show 'Leave' button during registration
- allow self-removal from participants list
- minor cleanup to leave endpoint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850fd54ec4c8322a9303224fd390223