### PR TITLE
Add gender field to user profile

### DIFF
--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -3,16 +3,16 @@ import connect from '../../../utils/mongoose';
 import User from '../../../models/User';
 
 export async function POST(request: Request) {
-  const { email, username } = await request.json();
+  const { email, username, gender } = await request.json();
   await connect();
   const existing = await User.findOne({ email });
   if (existing) {
     await User.updateOne(
       { email },
-      { username }
+      { username, gender }
     );
     return NextResponse.json({ success: true, message: 'Profile updated' });
   }
-  await User.create({ username, email });
+  await User.create({ username, email, gender });
   return NextResponse.json({ success: true });
 }

--- a/app/create-profile/page.tsx
+++ b/app/create-profile/page.tsx
@@ -20,6 +20,7 @@ function CreateProfileClient() {
 
   const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
+  const [gender, setGender] = useState('');
   const [error, setError] = useState('');
 
   // Populate email from NextAuth session or query param
@@ -33,11 +34,15 @@ function CreateProfileClient() {
   }, [session, searchParams]);
 
   const handleSubmit = async () => {
+    if (!gender) {
+      setError('Gender is required');
+      return;
+    }
     try {
       await request({
         url: '/api/signup',
         method: 'post',
-        data: { email, username },
+        data: { email, username, gender },
       });
       router.push('/login');
     } catch (e: any) {
@@ -61,6 +66,11 @@ function CreateProfileClient() {
           placeholder="Username"
           value={username}
           onChange={e => setUsername(e.target.value)}
+        />
+        <Input
+          placeholder="Gender"
+          value={gender}
+          onChange={e => setGender(e.target.value)}
         />
         {error && <p className="text-red-500 text-sm">{error}</p>}
         <Button className="w-full" onClick={handleSubmit}>

--- a/models/User.ts
+++ b/models/User.ts
@@ -3,6 +3,7 @@ import { Schema, model, models } from 'mongoose';
 const userSchema = new Schema({
   username: { type: String },
   email: { type: String, required: true, unique: true },
+  gender: { type: String },
   role: {
     type: String,
     enum: ['super-admin', 'admin', 'member'],


### PR DESCRIPTION
## Summary
- add `gender` property to the `User` schema
- allow `/api/signup` to store the provided gender
- require gender when creating a profile and send it to the API

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685365db16f08322a4723faa460ded26