### PR TITLE
Add level field to user profile

### DIFF
--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -3,16 +3,16 @@ import connect from '../../../utils/mongoose';
 import User from '../../../models/User';
 
 export async function POST(request: Request) {
-  const { email, username, gender } = await request.json();
+  const { email, username, gender, level } = await request.json();
   await connect();
   const existing = await User.findOne({ email });
   if (existing) {
     await User.updateOne(
       { email },
-      { username, gender }
+      { username, gender, level }
     );
     return NextResponse.json({ success: true, message: 'Profile updated' });
   }
-  await User.create({ username, email, gender });
+  await User.create({ username, email, gender, level });
   return NextResponse.json({ success: true });
 }

--- a/app/create-profile/page.tsx
+++ b/app/create-profile/page.tsx
@@ -21,6 +21,7 @@ function CreateProfileClient() {
   const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
   const [gender, setGender] = useState('');
+  const [level, setLevel] = useState('');
   const [error, setError] = useState('');
 
   // Populate email from NextAuth session or query param
@@ -38,11 +39,15 @@ function CreateProfileClient() {
       setError('Gender is required');
       return;
     }
+    if (!level) {
+      setError('Level is required');
+      return;
+    }
     try {
       await request({
         url: '/api/signup',
         method: 'post',
-        data: { email, username, gender },
+        data: { email, username, gender, level },
       });
       router.push('/login');
     } catch (e: any) {
@@ -71,6 +76,11 @@ function CreateProfileClient() {
           placeholder="Gender"
           value={gender}
           onChange={e => setGender(e.target.value)}
+        />
+        <Input
+          placeholder="Level"
+          value={level}
+          onChange={e => setLevel(e.target.value)}
         />
         {error && <p className="text-red-500 text-sm">{error}</p>}
         <Button className="w-full" onClick={handleSubmit}>

--- a/models/User.ts
+++ b/models/User.ts
@@ -4,6 +4,7 @@ const userSchema = new Schema({
   username: { type: String },
   email: { type: String, required: true, unique: true },
   gender: { type: String },
+  level: { type: String },
   role: {
     type: String,
     enum: ['super-admin', 'admin', 'member'],


### PR DESCRIPTION
## Summary
- extend User model with `level` field
- capture user's level on create profile page
- send level to signup API

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854cfbd64f88322a57f82345a5d0d05