### PR TITLE
Fix mobile viewport overflow

### DIFF
--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react'
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <SessionProvider>
-      <div className="flex flex-col min-h-screen">
+      <div className="flex flex-col min-h-dvh">
         <AppBar />
         <main className="flex-grow">{children}</main>
       </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,9 +19,12 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, viewport-fit=cover"
+        />
       </head>
-      <body suppressHydrationWarning className="min-h-screen">
+      <body suppressHydrationWarning className="min-h-dvh overflow-x-hidden">
         <Providers>
           {children}
         </Providers>


### PR DESCRIPTION
## Summary
- fix the viewport meta to support mobile URL bar hiding
- set body to use dynamic viewport height and hide horizontal overflow
- ensure layout container also uses dynamic viewport height

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685633946a908322b0f9db88c6b492ef