### PR TITLE
Add nickname & wechatId fields

### DIFF
--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -3,16 +3,16 @@ import connect from '../../../utils/mongoose';
 import User from '../../../models/User';
 
 export async function POST(request: Request) {
-  const { email, username, gender } = await request.json();
+  const { email, username, gender, nickname, wechatId } = await request.json();
   await connect();
   const existing = await User.findOne({ email });
   if (existing) {
     await User.updateOne(
       { email },
-      { username, gender }
+      { username, gender, nickname, wechatId }
     );
     return NextResponse.json({ success: true, message: 'Profile updated' });
   }
-  await User.create({ username, email, gender });
+  await User.create({ username, email, gender, nickname, wechatId });
   return NextResponse.json({ success: true });
 }

--- a/app/create-profile/page.tsx
+++ b/app/create-profile/page.tsx
@@ -21,6 +21,8 @@ function CreateProfileClient() {
   const [email, setEmail] = useState('');
   const [username, setUsername] = useState('');
   const [gender, setGender] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [wechatId, setWechatId] = useState('');
   const [error, setError] = useState('');
 
   // Populate email from NextAuth session or query param
@@ -42,7 +44,7 @@ function CreateProfileClient() {
       await request({
         url: '/api/signup',
         method: 'post',
-        data: { email, username, gender },
+        data: { email, username, gender, nickname, wechatId },
       });
       router.push('/login');
     } catch (e: any) {
@@ -68,9 +70,19 @@ function CreateProfileClient() {
           onChange={e => setUsername(e.target.value)}
         />
         <Input
+          placeholder="Nickname"
+          value={nickname}
+          onChange={e => setNickname(e.target.value)}
+        />
+        <Input
           placeholder="Gender"
           value={gender}
           onChange={e => setGender(e.target.value)}
+        />
+        <Input
+          placeholder="WeChat ID"
+          value={wechatId}
+          onChange={e => setWechatId(e.target.value)}
         />
         {error && <p className="text-red-500 text-sm">{error}</p>}
         <Button className="w-full" onClick={handleSubmit}>

--- a/models/User.ts
+++ b/models/User.ts
@@ -4,6 +4,8 @@ const userSchema = new Schema({
   username: { type: String },
   email: { type: String, required: true, unique: true },
   gender: { type: String },
+  nickname: { type: String },
+  wechatId: { type: String },
   role: {
     type: String,
     enum: ['super-admin', 'admin', 'member'],


### PR DESCRIPTION
## Summary
- extend `User` model with `nickname` and `wechatId`
- capture new profile fields on create profile form
- store nickname and wechatId in signup API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68563ed8b77483228c37ce332fb1ca6a