### PR TITLE
Fix missing email on profile creation

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -90,8 +90,8 @@ export const authOptions: NextAuthOptions = {
           clubs: [],
         });
       }
-      // Redirect new users to create-profile
-      return "/create-profile";
+      // Redirect new users to create-profile with email in query params
+      return `/create-profile?email=${encodeURIComponent(user.email || "")}`;
     },
     async redirect({ url, baseUrl }) {
       // If redirecting to create-profile, allow it


### PR DESCRIPTION
## Summary
- append the user's email as a query string when redirecting new Google signups to `/create-profile`
- run lint and build to verify

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68564ea846b08322babe8427a8544cc2