### PR TITLE
Fix mobile scroll jump

### DIFF
--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react'
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <SessionProvider>
-      <div className="flex flex-col min-h-dvh">
+      <div className="flex flex-col min-h-screen">
         <AppBar />
         <main className="flex-grow">{children}</main>
       </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
           content="width=device-width, initial-scale=1, viewport-fit=cover"
         />
       </head>
-      <body suppressHydrationWarning className="min-h-dvh overflow-x-hidden">
+      <body suppressHydrationWarning className="min-h-screen overflow-x-hidden">
         <Providers>
           {children}
         </Providers>


### PR DESCRIPTION
## Summary
- fix the mobile Chrome jumping to the top when scrolling by using `min-h-screen` instead of `min-h-dvh`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685700c94d1883229bb8fd25e97e6ea0