### PR TITLE
Implement fixed App Shell layout

### DIFF
--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -1,15 +1,17 @@
 'use client'
 
 import AppBar from '@/components/AppBar'
+import AppFooter from '@/components/AppFooter'
 import { SessionProvider } from 'next-auth/react'
 import type { ReactNode } from 'react'
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <SessionProvider>
-      <div className="flex flex-col min-h-dvh">
+      <div className="flex flex-col h-full">
         <AppBar />
-        <main className="flex-grow">{children}</main>
+        <main className="flex-grow overflow-y-auto">{children}</main>
+        <AppFooter />
       </div>
     </SessionProvider>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
           content="width=device-width, initial-scale=1, viewport-fit=cover"
         />
       </head>
-      <body suppressHydrationWarning className="min-h-dvh overflow-x-hidden overscroll-contain">
+        <body suppressHydrationWarning className="h-dvh overflow-x-hidden overflow-y-hidden overscroll-contain">
         <Providers>
           {children}
         </Providers>

--- a/components/AppFooter.tsx
+++ b/components/AppFooter.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Button } from './ui/button'
+
+export default function AppFooter() {
+  const pathname = usePathname()
+  const isHome = pathname === '/'
+  const isProfile = pathname === '/profile'
+
+  return (
+    <footer className="border-t p-2 flex items-center justify-around sticky bottom-0 bg-background">
+      <Button variant={isHome ? 'default' : 'outline'} asChild>
+        <Link href="/">Home</Link>
+      </Button>
+      <Button variant={isProfile ? 'default' : 'outline'} asChild>
+        <Link href="/profile">Profile</Link>
+      </Button>
+    </footer>
+  )
+}


### PR DESCRIPTION
## Summary
- lock the body height so it doesn't scroll
- make Providers fill the viewport and show a footer
- allow only the main content section to scroll
- add an AppFooter component with Home and Profile buttons

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68572ed8995483229d89da4b1b0f6157