### PR TITLE
Add footer navigation

### DIFF
--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import AppBar from '@/components/AppBar'
-import Footer from '@/components/Footer'
+import AppFooter from '@/components/AppFooter'
 import { SessionProvider } from 'next-auth/react'
 import type { ReactNode } from 'react'
 
@@ -11,7 +11,7 @@ export function Providers({ children }: { children: ReactNode }) {
       <div className="flex flex-col min-h-dvh">
         <AppBar />
         <main className="flex-grow pb-16">{children}</main>
-        <Footer />
+        <AppFooter />
       </div>
     </SessionProvider>
   );

--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import AppBar from '@/components/AppBar'
+import Footer from '@/components/Footer'
 import { SessionProvider } from 'next-auth/react'
 import type { ReactNode } from 'react'
 
@@ -9,7 +10,8 @@ export function Providers({ children }: { children: ReactNode }) {
     <SessionProvider>
       <div className="flex flex-col min-h-dvh">
         <AppBar />
-        <main className="flex-grow">{children}</main>
+        <main className="flex-grow pb-16">{children}</main>
+        <Footer />
       </div>
     </SessionProvider>
   );

--- a/components/AppFooter.tsx
+++ b/components/AppFooter.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { Home, Calendar, Users, User } from 'lucide-react'
 import { Button } from './ui/button'
 
-export default function Footer() {
+export default function AppFooter() {
   return (
     <nav className="fixed inset-x-0 bottom-0 z-50 border-t bg-background md:hidden">
       <div className="flex justify-around py-2">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import Link from 'next/link'
+import { Home, Calendar, Users, User } from 'lucide-react'
+import { Button } from './ui/button'
+
+export default function Footer() {
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-50 border-t bg-background md:hidden">
+      <div className="flex justify-around py-2">
+        <Button
+          variant="ghost"
+          asChild
+          className="flex flex-col items-center gap-1 text-xs"
+        >
+          <Link href="/">
+            <Home className="w-5 h-5" />
+            <span>Home</span>
+          </Link>
+        </Button>
+        <Button
+          variant="ghost"
+          asChild
+          className="flex flex-col items-center gap-1 text-xs"
+        >
+          <Link href="/event-edit">
+            <Calendar className="w-5 h-5" />
+            <span>Event</span>
+          </Link>
+        </Button>
+        <Button
+          variant="ghost"
+          asChild
+          className="flex flex-col items-center gap-1 text-xs"
+        >
+          <Link href="/user">
+            <Users className="w-5 h-5" />
+            <span>Club</span>
+          </Link>
+        </Button>
+        <Button
+          variant="ghost"
+          asChild
+          className="flex flex-col items-center gap-1 text-xs"
+        >
+          <Link href="/profile">
+            <User className="w-5 h-5" />
+            <span>Profile</span>
+          </Link>
+        </Button>
+      </div>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add new `Footer` component with navigation buttons
- include `Footer` in `Providers` layout and add padding to content

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685734b08d908322a2f4562282726e52