### PR TITLE
Fix Club schema missing error

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../../../auth';
 import connect from '../../../utils/mongoose';
 import User from '../../../models/User';
+import '../../../models/Club';
 import bcrypt from 'bcryptjs';
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);


### PR DESCRIPTION
## Summary
- fix the MissingSchemaError on `/api/profile` by importing the `Club` model

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857528143d08322a84d77e81193b616