### PR TITLE
Add event ranking page with navigation

### DIFF
--- a/app/events/[id]/ranking/page.tsx
+++ b/app/events/[id]/ranking/page.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useEventPage } from '@/hooks/useEventPage'
+import PageSkeleton from '@/components/PageSkeleton'
+import UserCard from '@/components/UserCard'
+
+export default function EventRankingPage({ params }: { params: { id: string } }) {
+  const {
+    event,
+    matches,
+  } = useEventPage(params.id)
+
+  if (!event) {
+    return <PageSkeleton />
+  }
+
+  const rankingMap: Record<string, { user: any; margin: number }> = {}
+
+  matches.forEach(match => {
+    const [a, b] = match.teams
+    if (a.score !== b.score) {
+      const winning = a.score > b.score ? a : b
+      const margin = Math.abs(a.score - b.score)
+      winning.players.forEach((p: any) => {
+        const pid = p.id
+        if (!rankingMap[pid]) {
+          rankingMap[pid] = { user: p, margin: 0 }
+        }
+        rankingMap[pid].margin += margin
+      })
+    }
+  })
+
+  const ranking = Object.values(rankingMap).sort((x, y) => y.margin - x.margin)
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Ranking</h1>
+      <div className="space-y-2">
+        {ranking.length === 0 ? (
+          <p>No results yet.</p>
+        ) : (
+          ranking.map(r => (
+            <div key={r.user.id} className="flex justify-between items-center">
+              <UserCard user={r.user} />
+              <span className="font-semibold">{r.margin}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { signOut, useSession } from 'next-auth/react'
 import { Button } from './ui/button'
 import {
@@ -10,11 +10,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu'
-import { Menu } from 'lucide-react'
+import { Menu, Home, Trophy } from 'lucide-react'
 
 
 export default function AppBar() {
   const router = useRouter()
+  const pathname = usePathname()
   const { data: session } = useSession()
 
   const handleLogout = async () => {
@@ -22,10 +23,23 @@ export default function AppBar() {
     router.push('/')
   }
 
+  const eventMatch = pathname.match(/^\/events\/(\w+)/)
+  const eventId = eventMatch ? eventMatch[1] : null
+
   return (
     <nav className="sticky top-0 z-50 flex items-center justify-between bg-gray-100 border-b px-4 py-2">
       <Link href="/" className="font-semibold">PAiMO</Link>
-      <div className="space-x-4 flex items-center relative">
+      <div className="flex items-center space-x-2 relative">
+        {eventId && (
+          <>
+            <Button variant="ghost" size="icon" asChild>
+              <Link href={`/events/${eventId}`}><Home className="h-5 w-5" /></Link>
+            </Button>
+            <Button variant="ghost" size="icon" asChild>
+              <Link href={`/events/${eventId}/ranking`}><Trophy className="h-5 w-5" /></Link>
+            </Button>
+          </>
+        )}
         {!session ? (
           <Link href="/login" className="hover:underline">Login</Link>
         ) : (


### PR DESCRIPTION
## Summary
- add a new ranking page for events
- show quick event navigation buttons in the app bar
- compute ranking by sum of winning margins

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858862996b48322804c012b34224821