### PR TITLE
Hide footer when user not logged in

### DIFF
--- a/components/AppFooter.tsx
+++ b/components/AppFooter.tsx
@@ -2,11 +2,14 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { useSession } from 'next-auth/react'
 import { Button } from './ui/button'
 import { Home, CalendarDays, Users, User } from 'lucide-react'
 
 export default function AppFooter() {
+  const { data: session } = useSession()
   const pathname = usePathname()
+  if (!session) return null
   const isHome = pathname === '/'
   const isEvents = pathname.startsWith('/events') || pathname === '/event-edit'
   const isClubs = pathname.startsWith('/clubs') || pathname === '/user'


### PR DESCRIPTION
## Summary
- don't display footer navigation unless a session exists

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858968203848322a2943cdc282df35d