### PR TITLE
Fix signup password creation

### DIFF
--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -4,10 +4,16 @@ import AppBar from '@/components/AppBar'
 import AppFooter from '@/components/AppFooter'
 import { SessionProvider } from 'next-auth/react'
 import type { ReactNode } from 'react'
-
-export function Providers({ children }: { children: ReactNode }) {
+import type { Session } from 'next-auth'
+export function Providers({
+  children,
+  session,
+}: {
+  children: ReactNode
+  session: Session | null
+}) {
   return (
-    <SessionProvider>
+    <SessionProvider session={session}>
       <div className="flex flex-col h-full">
         <AppBar />
         <main className="flex-grow overflow-y-auto">{children}</main>

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import connect from '../../../utils/mongoose';
 import User from '../../../models/User';
+import bcrypt from 'bcryptjs';
 
 export async function POST(request: Request) {
   try {
-    const { email, username, gender, nickname, wechatId } = await request.json()
+    const { email, username, gender, nickname, wechatId, password } = await request.json()
 
     if (!email) {
       return NextResponse.json(
@@ -15,9 +16,15 @@ export async function POST(request: Request) {
 
     await connect()
 
+    const update: any = { username, gender, nickname, wechatId }
+    if (password) {
+      const hashed = await bcrypt.hash(password, 10)
+      update.password = hashed
+    }
+
     const updated = await User.findOneAndUpdate(
       { email },
-      { $set: { username, gender, nickname, wechatId } },
+      { $set: update },
       { new: true, upsert: true }
     )
 

--- a/app/api/verify-email/route.ts
+++ b/app/api/verify-email/route.ts
@@ -14,10 +14,10 @@ export async function GET(req: Request) {
   if (!pending) {
     return NextResponse.json({ error: 'Invalid or expired token' }, { status: 400 });
   }
-  const { email, password } = pending;
+  const { email } = pending;
   const existing = await User.findOne({ email });
   if (!existing) {
-    await User.create({ email, password });
+    await User.create({ email });
   }
   await PendingUser.deleteOne({ token });
   return NextResponse.redirect(

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Providers } from "./Providers";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth";
 
 
 
@@ -11,11 +13,12 @@ export const metadata: Metadata = {
   description: "PAiMO is a club/event manage web app build for our lovely PIV Club members",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
+  const session = await getServerSession(authOptions)
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -24,12 +27,12 @@ export default function RootLayout({
           content="width=device-width, initial-scale=1, viewport-fit=cover"
         />
       </head>
-        <body suppressHydrationWarning className="h-dvh overflow-x-hidden overflow-y-hidden overscroll-contain">
-        <Providers>
+      <body suppressHydrationWarning className="h-dvh overflow-x-hidden overflow-y-hidden overscroll-contain">
+        <Providers session={session}>
           {children}
         </Providers>
       </body>
     </html>
-  );
+  )
 }
 


### PR DESCRIPTION
## Summary
- hash and store password in signup API
- remove undefined password field in verify email route
- provide server session to `SessionProvider` so users stay signed in after completing profile

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685909771ff48321a2e397c9fb72496f