### PR TITLE
Add leave event confirmation

### DIFF
--- a/components/event/ConfirmLeaveDialog.tsx
+++ b/components/event/ConfirmLeaveDialog.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface ConfirmLeaveDialogProps {
+    open: boolean
+    onClose: () => void
+    onConfirm: () => Promise<void>
+}
+
+export default function ConfirmLeaveDialog({ open, onClose, onConfirm }: ConfirmLeaveDialogProps) {
+    return (
+        <Dialog open={open} onOpenChange={onClose}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Leave Event?</DialogTitle>
+                </DialogHeader>
+                <DialogDescription>
+                    Are you sure you want to leave this event?
+                </DialogDescription>
+                <DialogFooter className="flex-col justify-center gap-2">
+                    <Button variant="outline" onClick={onClose}>Cancel</Button>
+                    <Button variant="destructive" onClick={async () => { await onConfirm(); onClose(); }}>Leave</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/components/event/RegistrationControls.tsx
+++ b/components/event/RegistrationControls.tsx
@@ -1,14 +1,27 @@
-import { Button } from '@/components/ui/button';
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import ConfirmLeaveDialog from '@/components/event/ConfirmLeaveDialog'
 
 interface Props {
-    canRegister: boolean;
-    canUnregister: boolean;
-    onRegister: () => void;
-    onUnregister: () => void;
+    canRegister: boolean
+    canUnregister: boolean
+    onRegister: () => void
+    onUnregister: () => Promise<void>
 }
 
 export default function RegistrationControls({ canRegister, canUnregister, onRegister, onUnregister }: Props) {
-    if (canRegister) return <Button onClick={onRegister}>Register</Button>;
-    if (canUnregister) return <Button onClick={onUnregister}>Leave</Button>;
-    return null;
+    const [showLeaveConfirm, setShowLeaveConfirm] = useState(false)
+
+    if (canRegister) return <Button onClick={onRegister}>Register</Button>
+    if (canUnregister) return (
+        <>
+            <Button onClick={() => setShowLeaveConfirm(true)}>Leave</Button>
+            <ConfirmLeaveDialog
+                open={showLeaveConfirm}
+                onClose={() => setShowLeaveConfirm(false)}
+                onConfirm={onUnregister}
+            />
+        </>
+    )
+    return null
 }


### PR DESCRIPTION
## Summary
- add confirmation dialog when leaving an event
- adjust registration control logic for confirm step

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859caa5e4488321b8edcb385c104d8d