### PR TITLE
Allow admins to register for events

### DIFF
--- a/hooks/useEventPage.ts
+++ b/hooks/useEventPage.ts
@@ -28,7 +28,6 @@ export function useEventPage(eventId: string) {
     const isAdmin = session?.user?.role === 'admin' || session?.user?.role === 'super-admin';
     const isParticipant = !!(event?.participants || []).find((p: any) => p.id === session?.user?.id);
     const canRegister =
-        !isAdmin &&
         !isParticipant &&
         event?.status === 'registration' &&
         (!event?.registrationEndTime || dayjs(event.registrationEndTime).isAfter(dayjs())) &&
@@ -40,7 +39,6 @@ export function useEventPage(eventId: string) {
         );
 
     const canUnregister =
-        !isAdmin &&
         isParticipant &&
         event?.status === 'registration' &&
         (!event?.registrationEndTime || dayjs(event.registrationEndTime).isAfter(dayjs()));


### PR DESCRIPTION
## Summary
- remove admin restriction in event registration checks

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859cffbb4808321949f9ce6befb0ad1