### PR TITLE
Add DB-backed push subscription storage

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -3,46 +3,65 @@
 import webpush from 'web-push'
 
 webpush.setVapidDetails(
-    'mailto:davidhe92@hotmail.com',
-    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
-    process.env.VAPID_PRIVATE_KEY!
+  'mailto:davidhe92@hotmail.com',
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
+  process.env.VAPID_PRIVATE_KEY!
 )
 
 import type { PushSubscription as WebPushSubscription } from 'web-push'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/auth'
+import connect from '@/utils/mongoose'
+import PushSubscription from '@/models/PushSubscription'
 
 let subscription: WebPushSubscription | null = null
 
 export async function subscribeUser(sub: WebPushSubscription) {
-    subscription = sub
-    // In a production environment, you would want to store the subscription in a database
-    // For example: await db.subscriptions.create({ data: sub })
-    return { success: true }
+  subscription = sub
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return { success: false }
+  }
+
+  await connect()
+  await PushSubscription.findOneAndUpdate(
+    { user: session.user.id, endpoint: sub.endpoint },
+    { user: session.user.id, endpoint: sub.endpoint, keys: sub.keys },
+    { upsert: true, new: true }
+  )
+
+  return { success: true }
 }
 
 export async function unsubscribeUser() {
-    subscription = null
-    // In a production environment, you would want to remove the subscription from the database
-    // For example: await db.subscriptions.delete({ where: { ... } })
-    return { success: true }
+  const session = await getServerSession(authOptions)
+  if (session?.user?.id) {
+    await connect()
+    const query: any = { user: session.user.id }
+    if (subscription?.endpoint) query.endpoint = subscription.endpoint
+    await PushSubscription.deleteMany(query)
+  }
+  subscription = null
+  return { success: true }
 }
 
 export async function sendNotification(message: string) {
-    if (!subscription) {
-        throw new Error('No subscription available')
-    }
+  if (!subscription) {
+    throw new Error('No subscription available')
+  }
 
-    try {
-        await webpush.sendNotification(
-            subscription,
-            JSON.stringify({
-                title: 'Test Notification',
-                body: message,
-                icon: '/icon.png',
-            })
-        )
-        return { success: true }
-    } catch (error) {
-        console.error('Error sending push notification:', error)
-        return { success: false, error: 'Failed to send notification' }
-    }
+  try {
+    await webpush.sendNotification(
+      subscription,
+      JSON.stringify({
+        title: 'Test Notification',
+        body: message,
+        icon: '/icon.png',
+      })
+    )
+    return { success: true }
+  } catch (error) {
+    console.error('Error sending push notification:', error)
+    return { success: false, error: 'Failed to send notification' }
+  }
 }

--- a/models/PushSubscription.ts
+++ b/models/PushSubscription.ts
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+const { Schema, model, models } = mongoose;
+
+const pushSubscriptionSchema = new Schema(
+  {
+    user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    endpoint: { type: String, required: true, unique: true },
+    keys: {
+      p256dh: { type: String },
+      auth: { type: String },
+    },
+  },
+  { timestamps: true }
+);
+
+export default models.PushSubscription || model('PushSubscription', pushSubscriptionSchema);

--- a/utils/mongoose.ts
+++ b/utils/mongoose.ts
@@ -6,6 +6,7 @@ import '@/models/Event';
 import '@/models/Match';
 import '@/models/PendingUser';
 import '@/models/PasswordReset';
+import '@/models/PushSubscription';
 
 
 


### PR DESCRIPTION
## Summary
- implement `PushSubscription` model
- register model with mongoose
- store and remove subscriptions in `app/actions`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a3f0dfa6c83229920bb85d233ce5f