### PR TITLE
Update pending user flow

### DIFF
--- a/app/api/verify-email/route.ts
+++ b/app/api/verify-email/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
 import connect from '@/utils/mongoose';
-import User from '@/models/User';
 import PendingUser from '@/models/PendingUser';
 
 export async function GET(req: Request) {
@@ -15,12 +14,7 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'Invalid or expired token' }, { status: 400 });
   }
   const { email } = pending;
-  const existing = await User.findOne({ email });
-  if (!existing) {
-    await User.create({ email });
-  }
-  await PendingUser.deleteOne({ token });
   return NextResponse.redirect(
-    `${process.env.NEXT_PUBLIC_APP_URL}/create-profile?email=${encodeURIComponent(email)}`
+    `${process.env.NEXT_PUBLIC_APP_URL}/create-profile?email=${encodeURIComponent(email)}&token=${token}`
   );
 }

--- a/app/create-profile/page.tsx
+++ b/app/create-profile/page.tsx
@@ -30,12 +30,13 @@ function CreateProfileClient() {
   const [gender, setGender] = useState('');
   const [nickname, setNickname] = useState('');
   const [wechatId, setWechatId] = useState('');
+  const [token, setToken] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
   const [confirmPasswordError, setConfirmPasswordError] = useState('');
 
-  // Populate email from NextAuth session or query param
+  // Populate email and token from session or query params
   useEffect(() => {
     if (session?.user?.email) {
       setEmail(session.user.email);
@@ -43,6 +44,8 @@ function CreateProfileClient() {
       const param = searchParams.get('email');
       if (param) setEmail(param);
     }
+    const t = searchParams.get('token');
+    if (t) setToken(t);
   }, [session, searchParams]);
 
   const handleSubmit = async () => {
@@ -62,7 +65,7 @@ function CreateProfileClient() {
       await request({
         url: '/api/signup',
         method: 'post',
-        data: { email, username, gender, nickname, wechatId, password },
+        data: { email, token, username, gender, nickname, wechatId, password },
       });
       // login after signup using NextAuth credentials provider
       const res = await signIn('credentials', {

--- a/models/PendingUser.ts
+++ b/models/PendingUser.ts
@@ -4,7 +4,7 @@ const { Schema, model, models } = mongoose;
 const pendingUserSchema = new Schema({
   email: { type: String, required: true, unique: true },
   token: { type: String, required: true, unique: true },
-  createdAt: { type: Date, default: Date.now, expires: 3600 },
+  createdAt: { type: Date, default: Date.now },
 });
 
 export default models.PendingUser || model('PendingUser', pendingUserSchema);


### PR DESCRIPTION
## Summary
- keep pending user entries indefinitely
- redirect verify-email to create-profile with token
- require token when completing the profile
- remove pending entry only after profile completion

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a488e543c8321afa4ef82778f742f