### PR TITLE
Fix sticky tabs on event page

### DIFF
--- a/components/MatchesScheduleSection.tsx
+++ b/components/MatchesScheduleSection.tsx
@@ -65,7 +65,7 @@ export default function MatchesScheduleSection({ matches, onScoreUpdated }: Matc
             />
 
             <Tabs value={activeTab} onValueChange={setActiveTab}>
-                <TabsList>
+                <TabsList className="sticky top-12 z-30 -mx-4 px-4 w-full overflow-x-auto bg-background">
                     {sortedGroupKeys.map(groupIdx => (
                         <TabsTrigger key={groupIdx} value={String(groupIdx)}>
                             Group {String.fromCharCode(65 + groupIdx)}

--- a/components/StepIndicator.tsx
+++ b/components/StepIndicator.tsx
@@ -65,7 +65,7 @@ const Step = ({ title, isCompleted, isActive }: StepProps) => {
 export default function StepIndicator({ step }: StepIndicatorProps) {
   const currentIndex = EVENT_STEPS.indexOf(step)
   return (
-    <div className="flex flex-nowrap items-center gap-4 mb-4 overflow-x-auto h-16">
+    <div className="sticky top-12 z-40 -mx-4 px-4 flex flex-nowrap items-center gap-4 mb-4 overflow-x-auto h-16 bg-background">
       {EVENT_STEPS.map((s, index) => (
         <React.Fragment key={s}>
           <Step


### PR DESCRIPTION
## Summary
- make event step indicator sticky and full width
- keep match group tabs visible when scrolling

## Testing
- `npx -y next@latest lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b0293354c8322bd649d61244eb5e8